### PR TITLE
Cleanup PackageInfo.g

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -76,17 +76,15 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "Forms - Sesquilinear and Quadratic",
-  Autoload  := true),
+),
 
 Dependencies := rec(
   GAP := ">=4.8",
-  NeededOtherPackages := [["GAPDoc", ">= 1.6"]],
+  NeededOtherPackages := [],
   SuggestedOtherPackages := [],
   ExternalConditions := []),
 
-AvailabilityTest := function()
-    return true;
-  end,
+AvailabilityTest := ReturnTrue,
 
 BannerString := Concatenation( 
   "---------------------------------------------------------------------\n",
@@ -97,8 +95,6 @@ BannerString := Concatenation(
         " (", ~.Persons[2].WWWHome, ")\n",
    "For help, type: ?Forms \n",
   "---------------------------------------------------------------------\n" ),
-
-Autoload := false,
 
 TestFile := "tst/testall.g",
 


### PR DESCRIPTION
- remove unused Autoload
- drop dependency on GAPDoc (it is always loaded anyway, and at the same
  time forms does not actually need it to run)
- shorten AvailabilityTest