### PR TITLE
extend the GAP library functions `GO`, `GU`, etc.

### DIFF
--- a/lib/classic.gi
+++ b/lib/classic.gi
@@ -1,0 +1,993 @@
+#############################################################################
+##
+##  classic.gi            'Forms' package
+##
+##  Provide the methods for 'GO', 'SO', 'Omega', 'GU', 'SU', and 'Sp' that
+##  involve a prescribed invariant form.
+##
+
+
+#############################################################################
+##
+#F  PowerTransposedMat( <mat>, <q> )
+##
+##  Return the matrix which has at position (i,j) the entry <mat>[j,i]^<q>.
+##
+BindGlobal( "PowerTransposedMat", function( mat, q )
+    local nrows, ncols, result, i, j;
+
+    nrows:= NumberRows( mat );
+    ncols:= NumberColumns( mat );
+    if IsPlistRep( mat ) then
+#TODO: Provide 'NewZeroMatrix' for this case.
+      result:= NullMat( ncols, nrows, BaseDomain( mat ) );
+    else
+      result:= NewZeroMatrix( ConstructingFilter( mat ), BaseDomain( mat ),
+                              ncols, nrows );
+    fi;
+    for i in [ 1 .. nrows ] do
+      for j in [ 1 .. ncols ] do
+        result[j,i]:= mat[i,j]^q;
+      od;
+    od;
+
+    return result;
+    end );
+
+
+#############################################################################
+##
+#O  GeneralOrthogonalGroupCons( <filter>, <form> )
+#O  GeneralOrthogonalGroupCons( <filter>, <e>, <d>, <q>, <form> )
+#O  GeneralOrthogonalGroupCons( <filter>, <e>, <d>, <R>, <form> )
+##
+##  'GeneralOrthogonalGroup' is a plain function that is defined in the GAP
+##  library.
+##  It calls 'GeneralOrthogonalGroupCons',
+##  thus we have to declare the variants involving a quadratic form,
+##  and install the corresponding methods.
+##
+Perform(
+    [ IsMatrixObj, IsQuadraticForm, IsGroup and HasInvariantQuadraticForm ],
+    function( obj )
+      DeclareConstructor( "GeneralOrthogonalGroupCons",
+        [ IsGroup, obj ] );
+      DeclareConstructor( "GeneralOrthogonalGroupCons",
+        [ IsGroup, IsInt, IsPosInt, IsPosInt, obj ] );
+      DeclareConstructor( "GeneralOrthogonalGroupCons",
+        [ IsGroup, IsInt, IsPosInt, IsRing, obj ] );
+    end );
+
+
+#############################################################################
+##
+#M  GeneralOrthogonalGroupCons( <filt>, <form> )
+##
+InstallMethod( GeneralOrthogonalGroupCons,
+    "matrix group for matrix of form",
+    [ IsMatrixGroup and IsFinite, IsMatrixObj ],
+    { filt, mat } -> GeneralOrthogonalGroupCons( filt,
+                       QuadraticFormByMatrix( mat, BaseDomain( mat ) ) ) );
+
+InstallMethod( GeneralOrthogonalGroupCons,
+    "matrix group for group with form",
+    [ IsMatrixGroup and IsFinite, IsGroup and HasInvariantQuadraticForm ],
+    { filt, G } -> GeneralOrthogonalGroupCons( filt,
+                     QuadraticFormByMatrix(
+                       InvariantQuadraticForm( G ).matrix,
+                       FieldOfMatrixGroup( G ) ) ) );
+
+InstallMethod( GeneralOrthogonalGroupCons,
+    "matrix group for form",
+    [ IsMatrixGroup and IsFinite, IsQuadraticForm ],
+    function( filt, form )
+    local d, q, e;
+
+    d:= NumberRows( form!.matrix );
+    q:= Size( form!.basefield );
+    if IsOddInt( d ) then
+      e:= 0;
+    elif IsEllipticForm( form ) then
+      e:= -1;
+    else
+      e:= 1;
+    fi;
+    return GeneralOrthogonalGroupCons( filt, e, d, q, form );
+end );
+
+
+#############################################################################
+##
+#M  GeneralOrthogonalGroupCons( <filt>, <e>, <d>, <q>, <form> )
+##
+InstallMethod( GeneralOrthogonalGroupCons,
+    "matrix group for <e>, dimension, finite field size, matrix of form",
+    [ IsMatrixGroup and IsFinite,
+      IsInt,
+      IsPosInt,
+      IsPosInt,
+      IsMatrixObj ],
+    { filt, e, d, q, mat } -> GeneralOrthogonalGroupCons( filt, e, d, q,
+                                QuadraticFormByMatrix( mat, GF(q) ) ) );
+
+InstallMethod( GeneralOrthogonalGroupCons,
+    "matrix group for <e>, dimension, finite field size, group with form",
+    [ IsMatrixGroup and IsFinite,
+      IsInt,
+      IsPosInt,
+      IsPosInt,
+      IsGroup and HasInvariantQuadraticForm ],
+    { filt, e, d, q, G } -> GeneralOrthogonalGroupCons( filt, e, d, q,
+                              QuadraticFormByMatrix(
+                                InvariantQuadraticForm( G ).matrix, GF(q) ) ) );
+
+InstallMethod( GeneralOrthogonalGroupCons,
+    "matrix group for <e>, dimension, finite field size, form",
+    [ IsMatrixGroup and IsFinite,
+      IsInt,
+      IsPosInt,
+      IsPosInt,
+      IsQuadraticForm ],
+    function( filt, e, d, q, form )
+    local g, stored, wanted, mat1, mat2, mat, matinv, gens, gg;
+
+    # Create the default generators and form.
+    g:= GeneralOrthogonalGroupCons( filt, e, d, q );
+    stored:= InvariantQuadraticForm( g ).matrix;
+
+    # If the prescribed form fits then just return.
+    if stored = form!.matrix then
+      return g;
+    fi;
+
+    # Compute a base change matrix.
+    # (Check that the canonical forms are equal.)
+    wanted:= QuadraticFormByMatrix( stored, GF(q) );
+    mat1:= BaseChangeToCanonical( form );
+    mat2:= BaseChangeToCanonical( wanted );
+    if Forms_RESET( mat1 * form!.matrix * TransposedMat( mat1 ), d, q ) <>
+       Forms_RESET( mat2 * stored * TransposedMat( mat2 ), d, q ) then
+      Error( "canonical forms of <form> and <wanted> differ" );
+    fi;
+    mat:= mat2^-1 * mat1;
+    matinv:= mat^-1;
+
+    mat1:= BaseChangeToCanonical( form );
+    mat2:= BaseChangeToCanonical( QuadraticFormByMatrix( stored, GF(q) ) );
+    mat:= mat2^-1 * mat1;
+    matinv:= mat^-1;
+
+    # Create the group w.r.t. the prescribed form.
+    gens:= List( GeneratorsOfGroup( g ), x -> matinv * x * mat );
+    gg:= GroupWithGenerators( gens );
+
+    if HasSize( g ) then
+      SetSize( gg, Size( g ) );
+    fi;
+
+    if HasName( g ) then
+      SetName( gg, Name( g ) );
+    fi;
+
+    SetInvariantQuadraticForm( gg, rec( matrix:= form!.matrix ) );
+    if HasIsFullSubgroupGLorSLRespectingQuadraticForm( g ) then
+      SetIsFullSubgroupGLorSLRespectingQuadraticForm( gg,
+          IsFullSubgroupGLorSLRespectingQuadraticForm( g ) );
+    fi;
+
+    SetInvariantBilinearForm( gg, rec( matrix:= matinv * InvariantBilinearForm( g ).matrix * TransposedMat( matinv ) ) );
+    if q mod 2 = 1 and
+       HasIsFullSubgroupGLorSLRespectingBilinearForm( g ) then
+      SetIsFullSubgroupGLorSLRespectingBilinearForm( gg,
+          IsFullSubgroupGLorSLRespectingBilinearForm( g ) );
+    fi;
+
+    return gg;
+end );
+
+
+#############################################################################
+##
+#M  GeneralOrthogonalGroupCons( <filt>, <e>, <d>, <R>, <form> )
+##
+InstallMethod( GeneralOrthogonalGroupCons,
+    "matrix group for <e>, dimension, finite field, matrix of form",
+    [ IsMatrixGroup and IsFinite,
+      IsInt,
+      IsPosInt,
+      IsField and IsFinite,
+      IsMatrixObj ],
+    { filt, e, d, F, form } -> GeneralOrthogonalGroupCons( filt, e, d,
+                                 Size( F ),
+                                 QuadraticFormByMatrix( form, F ) ) );
+
+InstallMethod( GeneralOrthogonalGroupCons,
+    "matrix group for <e>, dimension, finite field, group with form",
+    [ IsMatrixGroup and IsFinite,
+      IsInt,
+      IsPosInt,
+      IsField and IsFinite,
+      IsGroup and HasInvariantQuadraticForm ],
+    { filt, e, d, F, G } -> GeneralOrthogonalGroupCons( filt, e, d,
+                              Size( F ),
+                              QuadraticFormByMatrix(
+                                InvariantQuadraticForm( G ).matrix, F ) ) );
+
+InstallMethod( GeneralOrthogonalGroupCons,
+    "matrix group for <e>, dimension, finite field, form",
+    [ IsMatrixGroup and IsFinite,
+      IsInt,
+      IsPosInt,
+      IsField and IsFinite,
+      IsQuadraticForm ],
+    { filt, e, d, F, form } -> GeneralOrthogonalGroupCons( filt, e, d,
+                                 Size( F ), form ) );
+
+
+#############################################################################
+##
+#O  SpecialOrthogonalGroupCons( <filter>, <form> )
+#O  SpecialOrthogonalGroupCons( <filter>, <e>, <d>, <q>, <form> )
+#O  SpecialOrthogonalGroupCons( <filter>, <e>, <d>, <R>, <form> )
+##
+##  'SpecialOrthogonalGroup' is a plain function that is defined in the GAP
+##  library.
+##  It calls 'SpecialOrthogonalGroupCons',
+##  thus we have to declare the variants involving a quadratic form,
+##  and install the corresponding methods.
+##
+Perform(
+    [ IsMatrixObj, IsQuadraticForm, IsGroup and HasInvariantQuadraticForm ],
+    function( obj )
+      DeclareConstructor( "SpecialOrthogonalGroupCons",
+        [ IsGroup, obj ] );
+      DeclareConstructor( "SpecialOrthogonalGroupCons",
+        [ IsGroup, IsInt, IsPosInt, IsPosInt, obj ] );
+      DeclareConstructor( "SpecialOrthogonalGroupCons",
+        [ IsGroup, IsInt, IsPosInt, IsRing, obj ] );
+    end );
+
+
+#############################################################################
+##
+#M  SpecialOrthogonalGroupCons( <filt>, <form> )
+##
+InstallMethod( SpecialOrthogonalGroupCons,
+    "matrix group for matrix of form",
+    [ IsMatrixGroup and IsFinite, IsMatrixObj ],
+    { filt, mat } -> SpecialOrthogonalGroupCons( filt,
+                       QuadraticFormByMatrix( mat, BaseDomain( mat ) ) ) );
+
+InstallMethod( SpecialOrthogonalGroupCons,
+    "matrix group for group with form",
+    [ IsMatrixGroup and IsFinite, IsGroup and HasInvariantQuadraticForm ],
+    { filt, G } -> SpecialOrthogonalGroupCons( filt,
+                     QuadraticFormByMatrix(
+                       InvariantQuadraticForm( G ).matrix,
+                       FieldOfMatrixGroup( G ) ) ) );
+
+InstallMethod( SpecialOrthogonalGroupCons,
+    "matrix group for form",
+    [ IsMatrixGroup and IsFinite, IsQuadraticForm ],
+    function( filt, form )
+    local d, q, e;
+
+    d:= NumberRows( form!.matrix );
+    q:= Size( form!.basefield );
+    if IsOddInt( d ) then
+      e:= 0;
+    elif IsEllipticForm( form ) then
+      e:= -1;
+    else
+      e:= 1;
+    fi;
+    return SpecialOrthogonalGroupCons( filt, e, d, q, form );
+end );
+
+
+#############################################################################
+##
+#M  SpecialOrthogonalGroupCons( <filt>, <e>, <d>, <q>, <form> )
+##
+InstallMethod( SpecialOrthogonalGroupCons,
+    "matrix group for <e>, dimension, finite field size, matrix of form",
+    [ IsMatrixGroup and IsFinite,
+      IsInt,
+      IsPosInt,
+      IsPosInt,
+      IsMatrixObj ],
+    { filt, e, d, q, mat } -> SpecialOrthogonalGroupCons( filt, e, d, q,
+                                QuadraticFormByMatrix( mat, GF(q) ) ) );
+
+InstallMethod( SpecialOrthogonalGroupCons,
+    "matrix group for <e>, dimension, finite field size, group with form",
+    [ IsMatrixGroup and IsFinite,
+      IsInt,
+      IsPosInt,
+      IsPosInt,
+      IsGroup and HasInvariantQuadraticForm ],
+    { filt, e, d, q, G } -> SpecialOrthogonalGroupCons( filt, e, d, q,
+                              QuadraticFormByMatrix(
+                                InvariantQuadraticForm( G ).matrix, GF(q) ) ) );
+
+InstallMethod( SpecialOrthogonalGroupCons,
+    "matrix group for <e>, dimension, finite field size, form",
+    [ IsMatrixGroup and IsFinite,
+      IsInt,
+      IsPosInt,
+      IsPosInt,
+      IsQuadraticForm ],
+    function( filt, e, d, q, form )
+    local g, stored, wanted, mat1, mat2, mat, matinv, gens, gg;
+
+    # Create the default generators and form.
+    g:= SpecialOrthogonalGroupCons( filt, e, d, q );
+    stored:= InvariantQuadraticForm( g ).matrix;
+
+    # If the prescribed form fits then just return.
+    if stored = form!.matrix then
+      return g;
+    fi;
+
+    # Compute a base change matrix.
+    # (Check that the canonical forms are equal.)
+    wanted:= QuadraticFormByMatrix( stored, GF(q) );
+    mat1:= BaseChangeToCanonical( form );
+    mat2:= BaseChangeToCanonical( wanted );
+    if Forms_RESET( mat1 * form!.matrix * TransposedMat( mat1 ), d, q ) <>
+       Forms_RESET( mat2 * stored * TransposedMat( mat2 ), d, q ) then
+      Error( "canonical forms of <form> and <wanted> differ" );
+    fi;
+    mat:= mat2^-1 * mat1;
+    matinv:= mat^-1;
+
+    # Create the group w.r.t. the prescribed form.
+    gens:= List( GeneratorsOfGroup( g ), x -> matinv * x * mat );
+    gg:= GroupWithGenerators( gens );
+
+    if HasSize( g ) then
+      SetSize( gg, Size( g ) );
+    fi;
+
+    if HasName( g ) then
+      SetName( gg, Name( g ) );
+    fi;
+
+    SetInvariantQuadraticForm( gg, rec( matrix:= form!.matrix ) );
+    if HasIsFullSubgroupGLorSLRespectingQuadraticForm( g ) then
+      SetIsFullSubgroupGLorSLRespectingQuadraticForm( gg,
+          IsFullSubgroupGLorSLRespectingQuadraticForm( g ) );
+    fi;
+
+    SetInvariantBilinearForm( gg, rec( matrix:= matinv * InvariantBilinearForm( g ).matrix * TransposedMat( matinv ) ) );
+    if q mod 2 = 1 and
+       HasIsFullSubgroupGLorSLRespectingBilinearForm( g ) then
+      SetIsFullSubgroupGLorSLRespectingBilinearForm( gg,
+          IsFullSubgroupGLorSLRespectingBilinearForm( g ) );
+    fi;
+
+    return gg;
+end );
+
+
+#############################################################################
+##
+#M  SpecialOrthogonalGroupCons( <filt>, <e>, <d>, <R>, <form> )
+##
+InstallMethod( SpecialOrthogonalGroupCons,
+    "matrix group for <e>, dimension, finite field, matrix of form",
+    [ IsMatrixGroup and IsFinite,
+      IsInt,
+      IsPosInt,
+      IsField and IsFinite,
+      IsMatrixObj ],
+    { filt, e, d, F, form } -> SpecialOrthogonalGroupCons( filt, e, d,
+                                 Size( F ),
+                                 QuadraticFormByMatrix( form, F ) ) );
+
+InstallMethod( SpecialOrthogonalGroupCons,
+    "matrix group for <e>, dimension, finite field, group with form",
+    [ IsMatrixGroup and IsFinite,
+      IsInt,
+      IsPosInt,
+      IsField and IsFinite,
+      IsGroup and HasInvariantQuadraticForm ],
+    { filt, e, d, F, G } -> SpecialOrthogonalGroupCons( filt, e, d,
+                              Size( F ),
+                              QuadraticFormByMatrix(
+                                InvariantQuadraticForm( G ).matrix, F ) ) );
+
+InstallMethod( SpecialOrthogonalGroupCons,
+    "matrix group for <e>, dimension, finite field, form",
+    [ IsMatrixGroup and IsFinite,
+      IsInt,
+      IsPosInt,
+      IsField and IsFinite,
+      IsQuadraticForm ],
+    { filt, e, d, F, form } -> SpecialOrthogonalGroupCons( filt, e, d,
+                                 Size( F ), form ) );
+
+
+#############################################################################
+##
+#O  OmegaCons( <filt>, <form> )
+#O  Omega( [<filt>, ]<form> )
+#O  Omega( [<filt>, ][<e>, ]<d>, <q>, <form> )
+##
+##  'Omega' is an operation hat is defined in the GAP library.
+##  Thus we have to declare the variants involving a quadratic form,
+##  and install the corresponding 'Omega' methods that call 'OmegaCons'.
+##
+##  Install the methods involving <form>, which may be either a matrix or
+##  a quadratic form or a group with stored 'InvariantQuadraticForm'.
+##  (The other methods have been installed in the GAP library.)
+##
+Perform(
+    [ IsMatrixObj, IsQuadraticForm, IsGroup and HasInvariantQuadraticForm ],
+    function( obj )
+      DeclareConstructor( "OmegaCons", [ IsGroup, obj ] );
+      DeclareConstructor( "OmegaCons", [ IsGroup, IsPosInt, IsPosInt, obj ] );
+      DeclareConstructor( "OmegaCons", [ IsGroup, IsInt, IsPosInt, IsPosInt, obj ] );
+
+      DeclareOperation( "Omega", [ obj ] );
+      InstallMethod( Omega, [ obj ], x -> OmegaCons( IsMatrixGroup, x ) );
+
+      DeclareOperation( "Omega", [ IsFunction, obj ] );
+      InstallMethod( Omega, [ IsFunction, obj ], OmegaCons );
+
+      DeclareOperation( "Omega", [ IsPosInt, IsPosInt, obj ] );
+      InstallMethod( Omega, [ IsPosInt, IsPosInt, obj ],
+        { d, q, x } -> OmegaCons( IsMatrixGroup, 0, d, q, x ) );
+
+      DeclareOperation( "Omega", [ IsFunction, IsPosInt, IsPosInt, obj ] );
+      InstallMethod( Omega, [ IsFunction, IsPosInt, IsPosInt, obj ],
+        { filt, d, q, x } -> OmegaCons( filt, 0, d, q, x ) );
+
+      DeclareOperation( "Omega", [ IsInt, IsPosInt, IsPosInt, obj ] );
+      InstallMethod( Omega, [ IsInt, IsPosInt, IsPosInt, obj ],
+        { e, d, q, x } -> OmegaCons( IsMatrixGroup, e, d, q, x ) );
+
+      DeclareOperation( "Omega", [ IsFunction, IsInt, IsPosInt, IsPosInt, obj ] );
+      InstallMethod( Omega, [ IsFunction, IsInt, IsPosInt, IsPosInt, obj ],
+        OmegaCons );
+    end );
+
+
+#############################################################################
+##
+#M  OmegaCons( <filt>, <form> )
+##
+InstallMethod( OmegaCons,
+    "matrix group for matrix of form",
+    [ IsMatrixGroup and IsFinite, IsMatrixObj ],
+    { filt, mat } -> OmegaCons( filt,
+                       QuadraticFormByMatrix( mat, BaseDomain( mat ) ) ) );
+
+InstallMethod( OmegaCons,
+    "matrix group for group with form",
+    [ IsMatrixGroup and IsFinite, IsGroup and HasInvariantQuadraticForm ],
+    { filt, G } -> OmegaCons( filt,
+                     QuadraticFormByMatrix(
+                       InvariantQuadraticForm( G ).matrix,
+                       FieldOfMatrixGroup( G ) ) ) );
+
+InstallMethod( OmegaCons,
+    "matrix group for form",
+    [ IsMatrixGroup and IsFinite, IsQuadraticForm ],
+    function( filt, form )
+    local d, q, e;
+
+    d:= NumberRows( form!.matrix );
+    q:= Size( form!.basefield );
+    if IsOddInt( d ) then
+      e:= 0;
+    elif IsEllipticForm( form ) then
+      e:= -1;
+    else
+      e:= 1;
+    fi;
+    return OmegaCons( filt, e, d, q, form );
+end );
+
+
+#############################################################################
+##
+#M  OmegaCons( <filt>, <e>, <d>, <q>, <form> )
+##
+InstallMethod( OmegaCons,
+    "matrix group for <e>, dimension, finite field size, matrix of form",
+    [ IsMatrixGroup and IsFinite,
+      IsInt,
+      IsPosInt,
+      IsPosInt,
+      IsMatrixObj ],
+    { filt, e, d, q, mat } -> OmegaCons( filt, e, d, q,
+                                QuadraticFormByMatrix( mat, GF(q) ) ) );
+
+InstallMethod( OmegaCons,
+    "matrix group for <e>, dimension, finite field size, group with form",
+    [ IsMatrixGroup and IsFinite,
+      IsInt,
+      IsPosInt,
+      IsPosInt,
+      IsGroup and HasInvariantQuadraticForm ],
+    { filt, e, d, q, G } -> OmegaCons( filt, e, d, q,
+                              QuadraticFormByMatrix(
+                                InvariantQuadraticForm( G ).matrix, GF(q) ) ) );
+
+InstallMethod( OmegaCons,
+    "matrix group for <e>, dimension, finite field size, form",
+    [ IsMatrixGroup and IsFinite,
+      IsInt,
+      IsPosInt,
+      IsPosInt,
+      IsQuadraticForm ],
+    function( filt, e, d, q, form )
+    local g, stored, wanted, mat1, mat2, mat, matinv, gens, gg;
+
+    # Create the default generators and form.
+    g:= OmegaCons( filt, e, d, q );
+    stored:= InvariantQuadraticForm( g ).matrix;
+
+    # If the prescribed form fits then just return.
+    if stored = form!.matrix then
+      return g;
+    fi;
+
+    # Compute a base change matrix.
+    # (Check that the canonical forms are equal.)
+    wanted:= QuadraticFormByMatrix( stored, GF(q) );
+    mat1:= BaseChangeToCanonical( form );
+    mat2:= BaseChangeToCanonical( wanted );
+    if Forms_RESET( mat1 * form!.matrix * TransposedMat( mat1 ), d, q ) <>
+       Forms_RESET( mat2 * stored * TransposedMat( mat2 ), d, q ) then
+      Error( "canonical forms of <form> and <wanted> differ" );
+    fi;
+    mat:= mat2^-1 * mat1;
+    matinv:= mat^-1;
+
+    # Create the group w.r.t. the prescribed form.
+    gens:= List( GeneratorsOfGroup( g ), x -> matinv * x * mat );
+    gg:= GroupWithGenerators( gens );
+
+    if HasSize( g ) then
+      SetSize( gg, Size( g ) );
+    fi;
+
+    if HasName( g ) then
+      SetName( gg, Name( g ) );
+    fi;
+
+    SetInvariantQuadraticForm( gg, rec( matrix:= form!.matrix ) );
+    if HasIsFullSubgroupGLorSLRespectingQuadraticForm( g ) then
+      SetIsFullSubgroupGLorSLRespectingQuadraticForm( gg,
+          IsFullSubgroupGLorSLRespectingQuadraticForm( g ) );
+    fi;
+
+    SetInvariantBilinearForm( gg, rec( matrix:= matinv * InvariantBilinearForm( g ).matrix * TransposedMat( matinv ) ) );
+    if q mod 2 = 1 and
+       HasIsFullSubgroupGLorSLRespectingBilinearForm( g ) then
+      SetIsFullSubgroupGLorSLRespectingBilinearForm( gg,
+          IsFullSubgroupGLorSLRespectingBilinearForm( g ) );
+    fi;
+
+    return gg;
+end );
+
+
+#############################################################################
+##
+#O  GeneralUnitaryGroupCons( <filter>, <form> )
+#O  GeneralUnitaryGroupCons( <filter>, <d>, <q>, <form> )
+##
+##  'GeneralUnitaryGroup' is a plain function that is defined in the GAP
+##  library.
+##  It calls 'GeneralUnitaryGroupCons',
+##  thus we have to declare the variants involving a quadratic form,
+##  and install the corresponding methods.
+##
+Perform(
+    [ IsMatrixObj, IsHermitianForm, IsGroup and HasInvariantSesquilinearForm ],
+    function( obj )
+      DeclareConstructor( "GeneralUnitaryGroupCons", [ IsGroup, obj ] );
+      DeclareConstructor( "GeneralUnitaryGroupCons",
+        [ IsGroup, IsPosInt, IsPosInt, obj ] );
+    end );
+
+
+#############################################################################
+##
+#M  GeneralUnitaryGroupCons( <filt>, <form> )
+##
+InstallMethod( GeneralUnitaryGroupCons,
+    "matrix group for matrix of form",
+    [ IsMatrixGroup and IsFinite, IsMatrixObj ],
+    function( filt, mat )
+    local q, form;
+
+    # Guess the intended field.
+    q:= Size( BaseDomain( mat ) );
+    if q = RootInt( q, 2 )^2 then
+      form:= HermitianFormByMatrix( mat, GF(q) );
+    else
+      form:= HermitianFormByMatrix( mat, GF(q^2) );
+    fi;
+    return GeneralUnitaryGroupCons( filt, form );
+    end );
+
+InstallMethod( GeneralUnitaryGroupCons,
+    "matrix group for group with form",
+    [ IsMatrixGroup and IsFinite, IsGroup and HasInvariantSesquilinearForm ],
+    { filt, G } -> GeneralUnitaryGroupCons( filt,
+                     HermitianFormByMatrix(
+                       InvariantSesquilinearForm( G ).matrix,
+                       FieldOfMatrixGroup( G ) ) ) );
+
+InstallMethod( GeneralUnitaryGroupCons,
+    "matrix group for form",
+    [ IsMatrixGroup and IsFinite, IsHermitianForm ],
+    { filt, form } -> GeneralUnitaryGroupCons( filt,
+                        NumberRows( form!.matrix ),
+                        RootInt( Size( form!.basefield ), 2 ), form ) );
+
+
+#############################################################################
+##
+#M  GeneralUnitaryGroupCons( <filt>, <d>, <q>, <form> )
+##
+InstallMethod( GeneralUnitaryGroupCons,
+    "matrix group for dimension, finite field size, matrix of form",
+    [ IsMatrixGroup and IsFinite,
+      IsPosInt,
+      IsPosInt,
+      IsMatrixObj ],
+    { filt, d, q, mat } -> GeneralUnitaryGroupCons( filt, d, q,
+                             HermitianFormByMatrix( mat, GF(q^2) ) ) );
+
+InstallMethod( GeneralUnitaryGroupCons,
+    "matrix group for dimension, finite field size, group with form",
+    [ IsMatrixGroup and IsFinite,
+      IsPosInt,
+      IsPosInt,
+      IsGroup and HasInvariantSesquilinearForm ],
+    { filt, d, q, G } -> GeneralUnitaryGroupCons( filt, d, q,
+                           HermitianFormByMatrix(
+                             InvariantSesquilinearForm( G ).matrix, GF(q^2) ) ) );
+
+InstallMethod( GeneralUnitaryGroupCons,
+    "matrix group for dimension, finite field size, form",
+    [ IsMatrixGroup and IsFinite,
+      IsPosInt,
+      IsPosInt,
+      IsHermitianForm ],
+    function( filt, d, q, form )
+    local g, stored, wanted, mat1, mat2, mat, matinv, gens, gg;
+
+    # Create the default generators and form.
+    g:= GeneralUnitaryGroupCons( filt, d, q );
+    stored:= InvariantSesquilinearForm( g ).matrix;
+
+    # If the prescribed form fits then just return.
+    if stored = form!.matrix then
+      return g;
+    fi;
+
+    # Compute a base change matrix.
+    # (Check that the canonical forms are equal.)
+    wanted:= HermitianFormByMatrix( stored, GF(q^2) );
+    mat1:= BaseChangeToCanonical( form );
+    mat2:= BaseChangeToCanonical( wanted );
+    if mat1 * form!.matrix * PowerTransposedMat( mat1, q ) <>
+       mat2 * stored * PowerTransposedMat( mat2, q ) then
+      Error( "canonical forms of <form> and <wanted> differ" );
+    fi;
+    mat:= mat2^-1 * mat1;
+    matinv:= mat^-1;
+
+    # Create the group w.r.t. the prescribed form.
+    gens:= List( GeneratorsOfGroup( g ), x -> matinv * x * mat );
+    gg:= GroupWithGenerators( gens );
+
+    if HasSize( g ) then
+      SetSize( gg, Size( g ) );
+    fi;
+
+    if HasName( g ) then
+      SetName( gg, Name( g ) );
+    fi;
+
+    SetInvariantSesquilinearForm( gg, rec( matrix:= form!.matrix ) );
+    if HasIsFullSubgroupGLorSLRespectingSesquilinearForm( g ) then
+      SetIsFullSubgroupGLorSLRespectingSesquilinearForm( gg,
+          IsFullSubgroupGLorSLRespectingSesquilinearForm( g ) );
+    fi;
+
+    return gg;
+end );
+
+
+#############################################################################
+##
+#O  SpecialUnitaryGroupCons( <filter>, <form> )
+#O  SpecialUnitaryGroupCons( <filter>, <d>, <q>, <form> )
+##
+##  'SpecialUnitaryGroup' is a plain function that is defined in the GAP
+##  library.
+##  It calls 'SpecialUnitaryGroupCons',
+##  thus we have to declare the variants involving a quadratic form,
+##  and install the corresponding methods.
+##
+Perform(
+    [ IsMatrixObj, IsHermitianForm, IsGroup and HasInvariantSesquilinearForm ],
+    function( obj )
+      DeclareConstructor( "SpecialUnitaryGroupCons", [ IsGroup, obj ] );
+      DeclareConstructor( "SpecialUnitaryGroupCons",
+        [ IsGroup, IsPosInt, IsPosInt, obj ] );
+    end );
+
+
+#############################################################################
+##
+#M  SpecialUnitaryGroupCons( <filt>, <form> )
+##
+InstallMethod( SpecialUnitaryGroupCons,
+    "matrix group for matrix of form",
+    [ IsMatrixGroup and IsFinite, IsMatrixObj ],
+    function( filt, mat )
+    local q, form;
+
+    # Guess the intended field.
+    q:= Size( BaseDomain( mat ) );
+    if q = RootInt( q, 2 )^2 then
+      form:= HermitianFormByMatrix( mat, GF(q) );
+    else
+      form:= HermitianFormByMatrix( mat, GF(q^2) );
+    fi;
+    return SpecialUnitaryGroupCons( filt, form );
+    end );
+
+InstallMethod( SpecialUnitaryGroupCons,
+    "matrix group for group with form",
+    [ IsMatrixGroup and IsFinite, IsGroup and HasInvariantSesquilinearForm ],
+    { filt, G } -> SpecialUnitaryGroupCons( filt,
+                     HermitianFormByMatrix(
+                       InvariantSesquilinearForm( G ).matrix,
+                       FieldOfMatrixGroup( G ) ) ) );
+
+InstallMethod( SpecialUnitaryGroupCons,
+    "matrix group for form",
+    [ IsMatrixGroup and IsFinite, IsHermitianForm ],
+    { filt, form } -> SpecialUnitaryGroupCons( filt,
+                        NumberRows( form!.matrix ),
+                        RootInt( Size( form!.basefield ), 2 ), form ) );
+
+
+#############################################################################
+##
+#M  SpecialUnitaryGroupCons( <filt>, <d>, <q>, <form> )
+##
+InstallMethod( SpecialUnitaryGroupCons,
+    "matrix group for dimension, finite field size, matrix of form",
+    [ IsMatrixGroup and IsFinite,
+      IsPosInt,
+      IsPosInt,
+      IsMatrixObj ],
+    { filt, d, q, mat } -> SpecialUnitaryGroupCons( filt, d, q,
+                             HermitianFormByMatrix( mat, GF(q^2) ) ) );
+
+InstallMethod( SpecialUnitaryGroupCons,
+    "matrix group for dimension, finite field size, group with form",
+    [ IsMatrixGroup and IsFinite,
+      IsPosInt,
+      IsPosInt,
+      IsGroup and HasInvariantSesquilinearForm ],
+    { filt, d, q, G } -> SpecialUnitaryGroupCons( filt, d, q,
+                           HermitianFormByMatrix(
+                             InvariantSesquilinearForm( G ).matrix, GF(q^2) ) ) );
+
+InstallMethod( SpecialUnitaryGroupCons,
+    "matrix group for dimension, finite field size, form",
+    [ IsMatrixGroup and IsFinite,
+      IsPosInt,
+      IsPosInt,
+      IsHermitianForm ],
+    function( filt, d, q, form )
+    local g, stored, wanted, mat1, mat2, mat, matinv, gens, gg;
+
+    # Create the default generators and form.
+    g:= SpecialUnitaryGroupCons( filt, d, q );
+    stored:= InvariantSesquilinearForm( g ).matrix;
+
+    # If the prescribed form fits then just return.
+    if stored = form!.matrix then
+      return g;
+    fi;
+
+    # Compute a base change matrix.
+    # (Check that the canonical forms are equal.)
+    wanted:= HermitianFormByMatrix( stored, GF(q^2) );
+    mat1:= BaseChangeToCanonical( form );
+    mat2:= BaseChangeToCanonical( wanted );
+    if mat1 * form!.matrix * PowerTransposedMat( mat1, q ) <>
+       mat2 * stored * PowerTransposedMat( mat2, q ) then
+      Error( "canonical forms of <form> and <wanted> differ" );
+    fi;
+    mat:= mat2^-1 * mat1;
+    matinv:= mat^-1;
+
+    # Create the group w.r.t. the prescribed form.
+    gens:= List( GeneratorsOfGroup( g ), x -> matinv * x * mat );
+    gg:= GroupWithGenerators( gens );
+
+    if HasSize( g ) then
+      SetSize( gg, Size( g ) );
+    fi;
+
+    if HasName( g ) then
+      SetName( gg, Name( g ) );
+    fi;
+
+    SetInvariantSesquilinearForm( gg, rec( matrix:= form!.matrix ) );
+    if HasIsFullSubgroupGLorSLRespectingSesquilinearForm( g ) then
+      SetIsFullSubgroupGLorSLRespectingSesquilinearForm( gg,
+          IsFullSubgroupGLorSLRespectingSesquilinearForm( g ) );
+    fi;
+
+    return gg;
+end );
+
+
+#############################################################################
+##
+#O  SymplecticGroupCons( <filter>, <form> )
+#O  SymplecticGroupCons( <filter>, <d>, <q>, <form> )
+#O  SymplecticGroupCons( <filter>, <d>, <R>, <form> )
+##
+##  'SymplecticGroup' is a plain function that is defined in the GAP
+##  library.
+##  It calls 'SymplecticGroupCons',
+##  thus we have to declare the variants involving a quadratic form,
+##  and install the corresponding methods.
+##
+Perform(
+    [ IsMatrixObj, IsBilinearForm, IsGroup and HasInvariantBilinearForm ],
+    function( obj )
+      DeclareConstructor( "SymplecticGroupCons", [ IsGroup, obj ] );
+      DeclareConstructor( "SymplecticGroupCons",
+        [ IsGroup, IsPosInt, IsPosInt, obj ] );
+      DeclareConstructor( "SymplecticGroupCons",
+        [ IsGroup, IsPosInt, IsRing, obj ] );
+    end );
+
+
+#############################################################################
+##
+#M  SymplecticGroupCons( <filt>, <form> )
+##
+InstallMethod( SymplecticGroupCons,
+    "matrix group for matrix of form",
+    [ IsMatrixGroup and IsFinite, IsMatrixObj ],
+    { filt, mat } -> SymplecticGroupCons( filt,
+                       BilinearFormByMatrix( mat, BaseDomain( mat ) ) ) );
+
+InstallMethod( SymplecticGroupCons,
+    "matrix group for group with form",
+    [ IsMatrixGroup and IsFinite, IsGroup and HasInvariantBilinearForm ],
+    { filt, G } -> SymplecticGroupCons( filt,
+                     BilinearFormByMatrix(
+                       InvariantBilinearForm( G ).matrix,
+                       FieldOfMatrixGroup( G ) ) ) );
+
+InstallMethod( SymplecticGroupCons,
+    "matrix group for form",
+    [ IsMatrixGroup and IsFinite, IsBilinearForm ],
+    { filt, form } -> SymplecticGroupCons( filt,
+                        NumberRows( form!.matrix ),
+                        Size( form!.basefield ), form ) );
+
+
+#############################################################################
+##
+#M  SymplecticGroupCons( <filt>, <d>, <q>, <form> )
+##
+InstallMethod( SymplecticGroupCons,
+    "matrix group for dimension, finite field size, matrix of form",
+    [ IsMatrixGroup and IsFinite,
+      IsPosInt,
+      IsPosInt,
+      IsMatrixObj ],
+    { filt, d, q, mat } -> SymplecticGroupCons( filt, d, q,
+                             BilinearFormByMatrix( mat, GF(q) ) ) );
+
+InstallMethod( SymplecticGroupCons,
+    "matrix group for dimension, finite field size, group with form",
+    [ IsMatrixGroup and IsFinite,
+      IsPosInt,
+      IsPosInt,
+      IsGroup and HasInvariantBilinearForm ],
+    { filt, d, q, G } -> SymplecticGroupCons( filt, d, q,
+                           BilinearFormByMatrix(
+                             InvariantBilinearForm( G ).matrix, GF(q) ) ) );
+
+InstallMethod( SymplecticGroupCons,
+    "matrix group for dimension, finite field size, form",
+    [ IsMatrixGroup and IsFinite,
+      IsPosInt,
+      IsPosInt,
+      IsBilinearForm ],
+    function( filt, d, q, form )
+    local g, stored, wanted, mat1, mat2, mat, matinv, gens, gg;
+
+    # Create the default generators and form.
+    g:= SymplecticGroupCons( filt, d, q );
+    stored:= InvariantBilinearForm( g ).matrix;
+
+    # If the prescribed form fits then just return.
+    if stored = form!.matrix then
+      return g;
+    fi;
+
+    # Compute a base change matrix.
+    # (Check that the canonical forms are equal.)
+    wanted:= BilinearFormByMatrix( stored, GF(q) );
+    mat1:= BaseChangeToCanonical( form );
+    mat2:= BaseChangeToCanonical( wanted );
+    if mat1 * form!.matrix * TransposedMat( mat1 ) <>
+       mat2 * stored * TransposedMat( mat2 ) then
+      Error( "canonical forms of <form> and <wanted> differ" );
+    fi;
+    mat:= mat2^-1 * mat1;
+    matinv:= mat^-1;
+
+    # Create the group w.r.t. the prescribed form.
+    gens:= List( GeneratorsOfGroup( g ), x -> matinv * x * mat );
+    gg:= GroupWithGenerators( gens );
+
+    if HasSize( g ) then
+      SetSize( gg, Size( g ) );
+    fi;
+
+    if HasName( g ) then
+      SetName( gg, Name( g ) );
+    fi;
+
+    SetInvariantBilinearForm( gg, rec( matrix:= form!.matrix ) );
+    if HasIsFullSubgroupGLorSLRespectingBilinearForm( g ) then
+      SetIsFullSubgroupGLorSLRespectingBilinearForm( gg,
+          IsFullSubgroupGLorSLRespectingBilinearForm( g ) );
+    fi;
+
+    return gg;
+end );
+
+
+#############################################################################
+##
+#M  SymplecticGroupCons( <filt>, <d>, <R>, <form> )
+##
+InstallMethod( SymplecticGroupCons,
+    "matrix group for dimension, finite field, matrix of form",
+    [ IsMatrixGroup and IsFinite,
+      IsPosInt,
+      IsField and IsFinite,
+      IsMatrixObj ],
+    { filt, d, F, form } -> SymplecticGroupCons( filt, d, Size( F ),
+                              BilinearFormByMatrix( form, F ) ) );
+
+InstallMethod( SymplecticGroupCons,
+    "matrix group for dimension, finite field, group with form",
+    [ IsMatrixGroup and IsFinite,
+      IsPosInt,
+      IsField and IsFinite,
+      IsGroup and HasInvariantBilinearForm ],
+    { filt, d, F, G } -> SymplecticGroupCons( filt, d, Size( F ),
+                           BilinearFormByMatrix(
+                             InvariantBilinearForm( G ).matrix, F ) ) );
+
+InstallMethod( SymplecticGroupCons,
+    "matrix group for dimension, finite field, form",
+    [ IsMatrixGroup and IsFinite,
+      IsPosInt,
+      IsField and IsFinite,
+      IsBilinearForm ],
+    { filt, d, F, form } -> SymplecticGroupCons( filt, d, Size( F ), form ) );

--- a/read.g
+++ b/read.g
@@ -14,3 +14,4 @@
 
 ReadPackage("forms", "lib/forms.gi");
 ReadPackage("forms", "lib/recognition.gi");
+ReadPackage("forms", "lib/classic.gi");

--- a/tst/classic.tst
+++ b/tst/classic.tst
@@ -1,0 +1,157 @@
+#@local is_equal, q, F, d, es, e, g, stored, pi, permmat, form, gg, F2
+
+gap> START_TEST( "Forms: classic.tst" );
+
+# Provide an auxiliary function (until GAP's '=' gets fast).
+gap> is_equal:= function( G1, G2 )
+>      return IsSubset( G1, GeneratorsOfGroup( G2 ) ) and
+>             IsSubset( G2, GeneratorsOfGroup( G1 ) );
+>    end;;
+
+# Test the creation of orthogonal groups.
+gap> for q in [ 2, 3, 4, 5, 7, 8 ] do
+>      F:= GF(q);
+>      for d in [ 3 .. 5 ] do
+>        if IsEvenInt( d ) then
+>          es:= [ -1, 1 ];
+>        else
+>          es:= [ 0 ];
+>        fi;
+>        for e in es do
+>          # GO(e,d,q)
+>          g:= GeneralOrthogonalGroup( e, d, q );
+>          stored:= InvariantQuadraticForm( g ).matrix;
+>          pi:= PermutationMat( (1,2,3), d, F );
+>          permmat:= pi * stored * TransposedMat( pi );
+>          form:= QuadraticFormByMatrix( stored, F );
+>          gg:= GeneralOrthogonalGroup( e, d, q, permmat );
+>          if not ( is_equal( g, GeneralOrthogonalGroup( g ) ) and
+>                   ( is_equal( g, GeneralOrthogonalGroup( stored ) ) or
+>                     BaseDomain( stored ) <> F ) and
+>                   is_equal( g, GeneralOrthogonalGroup( form ) ) and
+>                   is_equal( g, GeneralOrthogonalGroup( e, d, q, g ) ) and
+>                   is_equal( g, GeneralOrthogonalGroup( e, d, q, stored ) ) and
+>                   is_equal( g, GeneralOrthogonalGroup( e, d, q, form ) ) and
+>                   is_equal( g, GeneralOrthogonalGroup( e, d, F, g ) ) and
+>                   is_equal( g, GeneralOrthogonalGroup( e, d, F, stored ) ) and
+>                   is_equal( g, GeneralOrthogonalGroup( e, d, F, form ) ) and
+>                   IsSubset( gg, GeneratorsOfGroup( gg ) ) and
+>                   IsSubset( g, List( GeneratorsOfGroup( gg ), x -> x^pi ) ) ) then
+>            Error( "problem with GO(", e, ",", d, ",", q, ")" );
+>          fi;
+>          # SO(e,d,q)
+>          g:= SpecialOrthogonalGroup( e, d, q );
+>          stored:= InvariantQuadraticForm( g ).matrix;
+>          pi:= PermutationMat( (1,2,3), d, F );
+>          permmat:= pi * stored * TransposedMat( pi );
+>          form:= QuadraticFormByMatrix( stored, F );
+>          gg:= SpecialOrthogonalGroup( e, d, q, permmat );
+>          if not ( is_equal( g, SpecialOrthogonalGroup( g ) ) and
+>                   ( is_equal( g, SpecialOrthogonalGroup( stored ) ) or
+>                     BaseDomain( stored ) <> F ) and
+>                   is_equal( g, SpecialOrthogonalGroup( form ) ) and
+>                   is_equal( g, SpecialOrthogonalGroup( e, d, q, g ) ) and
+>                   is_equal( g, SpecialOrthogonalGroup( e, d, q, stored ) ) and
+>                   is_equal( g, SpecialOrthogonalGroup( e, d, q, form ) ) and
+>                   is_equal( g, SpecialOrthogonalGroup( e, d, F, g ) ) and
+>                   is_equal( g, SpecialOrthogonalGroup( e, d, F, stored ) ) and
+>                   is_equal( g, SpecialOrthogonalGroup( e, d, F, form ) ) and
+>                   IsSubset( gg, GeneratorsOfGroup( gg ) ) and
+>                   IsSubset( g, List( GeneratorsOfGroup( gg ), x -> x^pi ) ) ) then
+>            Error( "problem with SO(", e, ",", d, ",", q, ")" );
+>          fi;
+>          # Omega(e,d,q)
+>          g:= Omega( e, d, q );
+>          stored:= InvariantQuadraticForm( g ).matrix;
+>          pi:= PermutationMat( (1,2,3), d, F );
+>          permmat:= pi * stored * TransposedMat( pi );
+>          form:= QuadraticFormByMatrix( stored, F );
+>          gg:= Omega( e, d, q, permmat );
+>          if not ( is_equal( g, Omega( g ) ) and
+>                   ( is_equal( g, Omega( stored ) ) or
+>                     BaseDomain( stored ) <> F ) and
+>                   is_equal( g, Omega( form ) ) and
+>                   is_equal( g, Omega( e, d, q, g ) ) and
+>                   is_equal( g, Omega( e, d, q, stored ) ) and
+>                   is_equal( g, Omega( e, d, q, form ) ) and
+>                   IsSubset( gg, GeneratorsOfGroup( gg ) ) and
+>                   IsSubset( g, List( GeneratorsOfGroup( gg ), x -> x^pi ) ) ) then
+>            Error( "problem with Omega(", e, ",", d, ",", q, ")" );
+>          fi;
+>        od;
+>      od;
+>    od;
+
+# Test the creation of unitary groups.
+gap> for q in [ 2, 3, 4, 5, 7, 8, 9, 11, 13, 16, 17, 19, 23, 25 ] do
+>      F:= GF(q);
+>      F2:= GF(q^2);
+>      for d in [ 2 .. 8 ] do
+>        # GU(d,q)
+>        g:= GeneralUnitaryGroup( d, q );
+>        stored:= InvariantSesquilinearForm( g ).matrix;
+>        pi:= PermutationMat( (1,2), d, F );
+>        permmat:= pi * stored * TransposedMat( pi );
+>        form:= HermitianFormByMatrix( stored, F2 );
+>        gg:= GeneralUnitaryGroup( d, q, permmat );
+>        if not ( is_equal( g, GeneralUnitaryGroup( g ) ) and
+>                 ( is_equal( g, GeneralUnitaryGroup( stored ) ) or
+>                   BaseDomain( stored ) <> F ) and
+>                 is_equal( g, GeneralUnitaryGroup( form ) ) and
+>                 is_equal( g, GeneralUnitaryGroup( d, q, g ) ) and
+>                 is_equal( g, GeneralUnitaryGroup( d, q, stored ) ) and
+>                 is_equal( g, GeneralUnitaryGroup( d, q, form ) ) and
+>                 IsSubset( gg, GeneratorsOfGroup( gg ) ) and
+>                 IsSubset( g, List( GeneratorsOfGroup( gg ), x -> x^pi ) ) ) then
+>          Error( "problem with GU(", d, ",", q, ")" );
+>        fi;
+>        # SU(d,q)
+>        g:= SpecialUnitaryGroup( d, q );
+>        stored:= InvariantSesquilinearForm( g ).matrix;
+>        pi:= PermutationMat( (1,2), d, F );
+>        permmat:= pi * stored * TransposedMat( pi );
+>        form:= HermitianFormByMatrix( stored, F2 );
+>        gg:= SpecialUnitaryGroup( d, q, permmat );
+>        if not ( is_equal( g, SpecialUnitaryGroup( g ) ) and
+>                 ( is_equal( g, SpecialUnitaryGroup( stored ) ) or
+>                   BaseDomain( stored ) <> F ) and
+>                 is_equal( g, SpecialUnitaryGroup( form ) ) and
+>                 is_equal( g, SpecialUnitaryGroup( d, q, g ) ) and
+>                 is_equal( g, SpecialUnitaryGroup( d, q, stored ) ) and
+>                 is_equal( g, SpecialUnitaryGroup( d, q, form ) ) and
+>                 IsSubset( gg, GeneratorsOfGroup( gg ) ) and
+>                 IsSubset( g, List( GeneratorsOfGroup( gg ), x -> x^pi ) ) ) then
+>          Error( "problem with SU(", d, ",", q, ")" );
+>        fi;
+>      od;
+>    od;
+
+# Test the creation of symplectic groups.
+gap> for q in [ 2, 3, 4, 5, 7, 8, 9, 11, 13, 16, 17, 19, 23, 25 ] do
+>      F:= GF(q);
+>      for d in [ 2, 4 .. 8 ] do
+>        g:= SymplecticGroup( d, q );
+>        stored:= InvariantBilinearForm( g ).matrix;
+>        pi:= PermutationMat( (1,2), d, F );
+>        permmat:= pi * stored * TransposedMat( pi );
+>        form:= BilinearFormByMatrix( stored, F );
+>        gg:= SymplecticGroup( d, q, permmat );
+>        if not ( is_equal( g, SymplecticGroup( g ) ) and
+>                 ( is_equal( g, SymplecticGroup( stored ) ) or
+>                   BaseDomain( stored ) <> F ) and
+>                 is_equal( g, SymplecticGroup( form ) ) and
+>                 is_equal( g, SymplecticGroup( d, q, g ) ) and
+>                 is_equal( g, SymplecticGroup( d, q, stored ) ) and
+>                 is_equal( g, SymplecticGroup( d, q, form ) ) and
+>                 is_equal( g, SymplecticGroup( d, F, g ) ) and
+>                 is_equal( g, SymplecticGroup( d, F, stored ) ) and
+>                 is_equal( g, SymplecticGroup( d, F, form ) ) and
+>                 IsSubset( gg, GeneratorsOfGroup( gg ) ) and
+>                 IsSubset( g, List( GeneratorsOfGroup( gg ), x -> x^pi ) ) ) then
+>          Error( "problem with Sp(", d, ",", q, ")" );
+>        fi;
+>      od;
+>    od;
+
+##
+gap> STOP_TEST( "classic.tst" );

--- a/tst/classic.tst
+++ b/tst/classic.tst
@@ -39,6 +39,16 @@ gap> for q in [ 2, 3, 4, 5, 7, 8 ] do
 >                   IsSubset( g, List( GeneratorsOfGroup( gg ), x -> x^pi ) ) ) then
 >            Error( "problem with GO(", e, ",", d, ",", q, ")" );
 >          fi;
+>          if e = 0 then
+>            if not ( is_equal( g, GeneralOrthogonalGroup( d, q, g ) ) and
+>                     is_equal( g, GeneralOrthogonalGroup( d, q, stored ) ) and
+>                     is_equal( g, GeneralOrthogonalGroup( d, q, form ) ) and
+>                     is_equal( g, GeneralOrthogonalGroup( d, F, g ) ) and
+>                     is_equal( g, GeneralOrthogonalGroup( d, F, stored ) ) and
+>                     is_equal( g, GeneralOrthogonalGroup( d, F, form ) ) ) then
+>              Error( "problem with GO(", d, ",", q, ")" );
+>            fi;
+>          fi;
 >          # SO(e,d,q)
 >          g:= SpecialOrthogonalGroup( e, d, q );
 >          stored:= InvariantQuadraticForm( g ).matrix;
@@ -60,6 +70,16 @@ gap> for q in [ 2, 3, 4, 5, 7, 8 ] do
 >                   IsSubset( g, List( GeneratorsOfGroup( gg ), x -> x^pi ) ) ) then
 >            Error( "problem with SO(", e, ",", d, ",", q, ")" );
 >          fi;
+>          if e = 0 then
+>            if not ( is_equal( g, SpecialOrthogonalGroup( d, q, g ) ) and
+>                     is_equal( g, SpecialOrthogonalGroup( d, q, stored ) ) and
+>                     is_equal( g, SpecialOrthogonalGroup( d, q, form ) ) and
+>                     is_equal( g, SpecialOrthogonalGroup( d, F, g ) ) and
+>                     is_equal( g, SpecialOrthogonalGroup( d, F, stored ) ) and
+>                     is_equal( g, SpecialOrthogonalGroup( d, F, form ) ) ) then
+>              Error( "problem with SO(", d, ",", q, ")" );
+>            fi;
+>          fi;
 >          # Omega(e,d,q)
 >          g:= Omega( e, d, q );
 >          stored:= InvariantQuadraticForm( g ).matrix;
@@ -74,9 +94,22 @@ gap> for q in [ 2, 3, 4, 5, 7, 8 ] do
 >                   is_equal( g, Omega( e, d, q, g ) ) and
 >                   is_equal( g, Omega( e, d, q, stored ) ) and
 >                   is_equal( g, Omega( e, d, q, form ) ) and
+>                   is_equal( g, Omega( e, d, F, g ) ) and
+>                   is_equal( g, Omega( e, d, F, stored ) ) and
+>                   is_equal( g, Omega( e, d, F, form ) ) and
 >                   IsSubset( gg, GeneratorsOfGroup( gg ) ) and
 >                   IsSubset( g, List( GeneratorsOfGroup( gg ), x -> x^pi ) ) ) then
 >            Error( "problem with Omega(", e, ",", d, ",", q, ")" );
+>          fi;
+>          if e = 0 then
+>            if not ( is_equal( g, Omega( d, q, g ) ) and
+>                     is_equal( g, Omega( d, q, stored ) ) and
+>                     is_equal( g, Omega( d, q, form ) ) and
+>                     is_equal( g, Omega( d, F, g ) ) and
+>                     is_equal( g, Omega( d, F, stored ) ) and
+>                     is_equal( g, Omega( d, F, form ) ) ) then
+>              Error( "problem with Omega", d, ",", q, ")" );
+>            fi;
 >          fi;
 >        od;
 >      od;

--- a/tst/classic_self_contained.tst
+++ b/tst/classic_self_contained.tst
@@ -1,10 +1,10 @@
 #@local is_equal, q, F, d, es, e, g, stored, pi, permmat, form, gg, F2
 
-gap> START_TEST( "Forms: classic.tst" );
+gap> START_TEST( "Forms: classic_self_contained.tst" );
 
 # Test the methods for constructing classical groups w.r.t. prescribed forms,
-# by calling the global functions in the GAP library that delegate to these
-# methods.  Thus we also test these functions.
+# but without assuming that the global functions in the GAP library
+# already delegate to these methods.
 
 # Provide an auxiliary function (until GAP's '=' gets fast).
 gap> is_equal:= function( G1, G2 )
@@ -28,30 +28,20 @@ gap> for q in [ 2, 3, 4, 5, 7, 8 ] do
 >          pi:= PermutationMat( (1,2,3), d, F );
 >          permmat:= pi * stored * TransposedMat( pi );
 >          form:= QuadraticFormByMatrix( stored, F );
->          gg:= GeneralOrthogonalGroup( e, d, q, permmat );
->          if not ( is_equal( g, GeneralOrthogonalGroup( g ) ) and
->                   ( is_equal( g, GeneralOrthogonalGroup( stored ) ) or
+>          gg:= GeneralOrthogonalGroupCons( IsMatrixGroup, e, d, q, permmat );
+>          if not ( is_equal( g, GeneralOrthogonalGroupCons( IsMatrixGroup, g ) ) and
+>                   ( is_equal( g, GeneralOrthogonalGroupCons( IsMatrixGroup, stored ) ) or
 >                     BaseDomain( stored ) <> F ) and
->                   is_equal( g, GeneralOrthogonalGroup( form ) ) and
->                   is_equal( g, GeneralOrthogonalGroup( e, d, q, g ) ) and
->                   is_equal( g, GeneralOrthogonalGroup( e, d, q, stored ) ) and
->                   is_equal( g, GeneralOrthogonalGroup( e, d, q, form ) ) and
->                   is_equal( g, GeneralOrthogonalGroup( e, d, F, g ) ) and
->                   is_equal( g, GeneralOrthogonalGroup( e, d, F, stored ) ) and
->                   is_equal( g, GeneralOrthogonalGroup( e, d, F, form ) ) and
+>                   is_equal( g, GeneralOrthogonalGroupCons( IsMatrixGroup, form ) ) and
+>                   is_equal( g, GeneralOrthogonalGroupCons( IsMatrixGroup, e, d, q, g ) ) and
+>                   is_equal( g, GeneralOrthogonalGroupCons( IsMatrixGroup, e, d, q, stored ) ) and
+>                   is_equal( g, GeneralOrthogonalGroupCons( IsMatrixGroup, e, d, q, form ) ) and
+>                   is_equal( g, GeneralOrthogonalGroupCons( IsMatrixGroup, e, d, F, g ) ) and
+>                   is_equal( g, GeneralOrthogonalGroupCons( IsMatrixGroup, e, d, F, stored ) ) and
+>                   is_equal( g, GeneralOrthogonalGroupCons( IsMatrixGroup, e, d, F, form ) ) and
 >                   IsSubset( gg, GeneratorsOfGroup( gg ) ) and
 >                   IsSubset( g, List( GeneratorsOfGroup( gg ), x -> x^pi ) ) ) then
->            Error( "problem with GO(", e, ",", d, ",", q, ")" );
->          fi;
->          if e = 0 then
->            if not ( is_equal( g, GeneralOrthogonalGroup( d, q, g ) ) and
->                     is_equal( g, GeneralOrthogonalGroup( d, q, stored ) ) and
->                     is_equal( g, GeneralOrthogonalGroup( d, q, form ) ) and
->                     is_equal( g, GeneralOrthogonalGroup( d, F, g ) ) and
->                     is_equal( g, GeneralOrthogonalGroup( d, F, stored ) ) and
->                     is_equal( g, GeneralOrthogonalGroup( d, F, form ) ) ) then
->              Error( "problem with GO(", d, ",", q, ")" );
->            fi;
+>            Error( "problem with GeneralOrthogonalGroupCons( IsMatrixGroup, ", e, ",", d, ",", q, ")" );
 >          fi;
 >          # SO(e,d,q)
 >          g:= SpecialOrthogonalGroup( e, d, q );
@@ -59,30 +49,20 @@ gap> for q in [ 2, 3, 4, 5, 7, 8 ] do
 >          pi:= PermutationMat( (1,2,3), d, F );
 >          permmat:= pi * stored * TransposedMat( pi );
 >          form:= QuadraticFormByMatrix( stored, F );
->          gg:= SpecialOrthogonalGroup( e, d, q, permmat );
->          if not ( is_equal( g, SpecialOrthogonalGroup( g ) ) and
->                   ( is_equal( g, SpecialOrthogonalGroup( stored ) ) or
+>          gg:= SpecialOrthogonalGroupCons( IsMatrixGroup, e, d, q, permmat );
+>          if not ( is_equal( g, SpecialOrthogonalGroupCons( IsMatrixGroup, g ) ) and
+>                   ( is_equal( g, SpecialOrthogonalGroupCons( IsMatrixGroup, stored ) ) or
 >                     BaseDomain( stored ) <> F ) and
->                   is_equal( g, SpecialOrthogonalGroup( form ) ) and
->                   is_equal( g, SpecialOrthogonalGroup( e, d, q, g ) ) and
->                   is_equal( g, SpecialOrthogonalGroup( e, d, q, stored ) ) and
->                   is_equal( g, SpecialOrthogonalGroup( e, d, q, form ) ) and
->                   is_equal( g, SpecialOrthogonalGroup( e, d, F, g ) ) and
->                   is_equal( g, SpecialOrthogonalGroup( e, d, F, stored ) ) and
->                   is_equal( g, SpecialOrthogonalGroup( e, d, F, form ) ) and
+>                   is_equal( g, SpecialOrthogonalGroupCons( IsMatrixGroup, form ) ) and
+>                   is_equal( g, SpecialOrthogonalGroupCons( IsMatrixGroup, e, d, q, g ) ) and
+>                   is_equal( g, SpecialOrthogonalGroupCons( IsMatrixGroup, e, d, q, stored ) ) and
+>                   is_equal( g, SpecialOrthogonalGroupCons( IsMatrixGroup, e, d, q, form ) ) and
+>                   is_equal( g, SpecialOrthogonalGroupCons( IsMatrixGroup, e, d, F, g ) ) and
+>                   is_equal( g, SpecialOrthogonalGroupCons( IsMatrixGroup, e, d, F, stored ) ) and
+>                   is_equal( g, SpecialOrthogonalGroupCons( IsMatrixGroup, e, d, F, form ) ) and
 >                   IsSubset( gg, GeneratorsOfGroup( gg ) ) and
 >                   IsSubset( g, List( GeneratorsOfGroup( gg ), x -> x^pi ) ) ) then
->            Error( "problem with SO(", e, ",", d, ",", q, ")" );
->          fi;
->          if e = 0 then
->            if not ( is_equal( g, SpecialOrthogonalGroup( d, q, g ) ) and
->                     is_equal( g, SpecialOrthogonalGroup( d, q, stored ) ) and
->                     is_equal( g, SpecialOrthogonalGroup( d, q, form ) ) and
->                     is_equal( g, SpecialOrthogonalGroup( d, F, g ) ) and
->                     is_equal( g, SpecialOrthogonalGroup( d, F, stored ) ) and
->                     is_equal( g, SpecialOrthogonalGroup( d, F, form ) ) ) then
->              Error( "problem with SO(", d, ",", q, ")" );
->            fi;
+>            Error( "problem with SpecialOrthogonalGroupCons( IsMatrixGroup, ", e, ",", d, ",", q, ")" );
 >          fi;
 >          # Omega(e,d,q)
 >          g:= Omega( e, d, q );
@@ -130,17 +110,17 @@ gap> for q in [ 2, 3, 4, 5, 7, 8, 9, 11, 13, 16, 17, 19, 23, 25 ] do
 >        pi:= PermutationMat( (1,2), d, F );
 >        permmat:= pi * stored * TransposedMat( pi );
 >        form:= HermitianFormByMatrix( stored, F2 );
->        gg:= GeneralUnitaryGroup( d, q, permmat );
->        if not ( is_equal( g, GeneralUnitaryGroup( g ) ) and
->                 ( is_equal( g, GeneralUnitaryGroup( stored ) ) or
+>        gg:= GeneralUnitaryGroupCons( IsMatrixGroup, d, q, permmat );
+>        if not ( is_equal( g, GeneralUnitaryGroupCons( IsMatrixGroup, g ) ) and
+>                 ( is_equal( g, GeneralUnitaryGroupCons( IsMatrixGroup, stored ) ) or
 >                   BaseDomain( stored ) <> F ) and
->                 is_equal( g, GeneralUnitaryGroup( form ) ) and
->                 is_equal( g, GeneralUnitaryGroup( d, q, g ) ) and
->                 is_equal( g, GeneralUnitaryGroup( d, q, stored ) ) and
->                 is_equal( g, GeneralUnitaryGroup( d, q, form ) ) and
+>                 is_equal( g, GeneralUnitaryGroupCons( IsMatrixGroup, form ) ) and
+>                 is_equal( g, GeneralUnitaryGroupCons( IsMatrixGroup, d, q, g ) ) and
+>                 is_equal( g, GeneralUnitaryGroupCons( IsMatrixGroup, d, q, stored ) ) and
+>                 is_equal( g, GeneralUnitaryGroupCons( IsMatrixGroup, d, q, form ) ) and
 >                 IsSubset( gg, GeneratorsOfGroup( gg ) ) and
 >                 IsSubset( g, List( GeneratorsOfGroup( gg ), x -> x^pi ) ) ) then
->          Error( "problem with GU(", d, ",", q, ")" );
+>          Error( "problem with GeneralUnitaryGroupCons( IsMatrixGroup, ", d, ",", q, ")" );
 >        fi;
 >        # SU(d,q)
 >        g:= SpecialUnitaryGroup( d, q );
@@ -148,17 +128,17 @@ gap> for q in [ 2, 3, 4, 5, 7, 8, 9, 11, 13, 16, 17, 19, 23, 25 ] do
 >        pi:= PermutationMat( (1,2), d, F );
 >        permmat:= pi * stored * TransposedMat( pi );
 >        form:= HermitianFormByMatrix( stored, F2 );
->        gg:= SpecialUnitaryGroup( d, q, permmat );
->        if not ( is_equal( g, SpecialUnitaryGroup( g ) ) and
->                 ( is_equal( g, SpecialUnitaryGroup( stored ) ) or
+>        gg:= SpecialUnitaryGroupCons( IsMatrixGroup, d, q, permmat );
+>        if not ( is_equal( g, SpecialUnitaryGroupCons( IsMatrixGroup, g ) ) and
+>                 ( is_equal( g, SpecialUnitaryGroupCons( IsMatrixGroup, stored ) ) or
 >                   BaseDomain( stored ) <> F ) and
->                 is_equal( g, SpecialUnitaryGroup( form ) ) and
->                 is_equal( g, SpecialUnitaryGroup( d, q, g ) ) and
->                 is_equal( g, SpecialUnitaryGroup( d, q, stored ) ) and
->                 is_equal( g, SpecialUnitaryGroup( d, q, form ) ) and
+>                 is_equal( g, SpecialUnitaryGroupCons( IsMatrixGroup, form ) ) and
+>                 is_equal( g, SpecialUnitaryGroupCons( IsMatrixGroup, d, q, g ) ) and
+>                 is_equal( g, SpecialUnitaryGroupCons( IsMatrixGroup, d, q, stored ) ) and
+>                 is_equal( g, SpecialUnitaryGroupCons( IsMatrixGroup, d, q, form ) ) and
 >                 IsSubset( gg, GeneratorsOfGroup( gg ) ) and
 >                 IsSubset( g, List( GeneratorsOfGroup( gg ), x -> x^pi ) ) ) then
->          Error( "problem with SU(", d, ",", q, ")" );
+>          Error( "problem with SpecialUnitaryGroupCons( IsMatrixGroup, ", d, ",", q, ")" );
 >        fi;
 >      od;
 >    od;
@@ -172,23 +152,23 @@ gap> for q in [ 2, 3, 4, 5, 7, 8, 9, 11, 13, 16, 17, 19, 23, 25 ] do
 >        pi:= PermutationMat( (1,2), d, F );
 >        permmat:= pi * stored * TransposedMat( pi );
 >        form:= BilinearFormByMatrix( stored, F );
->        gg:= SymplecticGroup( d, q, permmat );
->        if not ( is_equal( g, SymplecticGroup( g ) ) and
->                 ( is_equal( g, SymplecticGroup( stored ) ) or
+>        gg:= SymplecticGroupCons( IsMatrixGroup, d, q, permmat );
+>        if not ( is_equal( g, SymplecticGroupCons( IsMatrixGroup, g ) ) and
+>                 ( is_equal( g, SymplecticGroupCons(IsMatrixGroup,  stored ) ) or
 >                   BaseDomain( stored ) <> F ) and
->                 is_equal( g, SymplecticGroup( form ) ) and
->                 is_equal( g, SymplecticGroup( d, q, g ) ) and
->                 is_equal( g, SymplecticGroup( d, q, stored ) ) and
->                 is_equal( g, SymplecticGroup( d, q, form ) ) and
->                 is_equal( g, SymplecticGroup( d, F, g ) ) and
->                 is_equal( g, SymplecticGroup( d, F, stored ) ) and
->                 is_equal( g, SymplecticGroup( d, F, form ) ) and
+>                 is_equal( g, SymplecticGroupCons( IsMatrixGroup, form ) ) and
+>                 is_equal( g, SymplecticGroupCons( IsMatrixGroup, d, q, g ) ) and
+>                 is_equal( g, SymplecticGroupCons( IsMatrixGroup, d, q, stored ) ) and
+>                 is_equal( g, SymplecticGroupCons( IsMatrixGroup, d, q, form ) ) and
+>                 is_equal( g, SymplecticGroupCons( IsMatrixGroup, d, F, g ) ) and
+>                 is_equal( g, SymplecticGroupCons( IsMatrixGroup, d, F, stored ) ) and
+>                 is_equal( g, SymplecticGroupCons( IsMatrixGroup, d, F, form ) ) and
 >                 IsSubset( gg, GeneratorsOfGroup( gg ) ) and
 >                 IsSubset( g, List( GeneratorsOfGroup( gg ), x -> x^pi ) ) ) then
->          Error( "problem with Sp(", d, ",", q, ")" );
+>          Error( "problem with SymplecticGroupCons( IsMatrixGroup, ", d, ",", q, ")" );
 >        fi;
 >      od;
 >    od;
 
 ##
-gap> STOP_TEST( "classic.tst" );
+gap> STOP_TEST( "classic_self_contained.tst" );

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -21,8 +21,13 @@ testfiles := [
 "test_forms13.tst",
 "test_forms14.tst",
 "test_forms15.tst",
-"test_forms16.tst"
+"test_forms16.tst",
+"classic_self_contained.tst",
 ];
+
+if CompareVersionNumbers( GAPInfo.Version, "4.12" ) then
+  Add( testfiles, "classic.tst" );
+fi;
 
 testresult:=true;
 for ff in testfiles do


### PR DESCRIPTION
... such that one can prescribe an invariant form.
This will work as soon as the corresponding extensions in the GAP library become available, see pull request gap-system/gap/pull/4489.

Some tests of the new code are provided in `tst/classic.tst`;
currently they are not processed automatically when `tst/testall.g` is run,
note that they require the corresponding changes in the GAP library.

(Documentation for the new functions is missing.)