### PR TITLE
Use CDATA for some manual examples

### DIFF
--- a/doc/examples.xml
+++ b/doc/examples.xml
@@ -34,7 +34,7 @@ Then this polynomial defines a quadratic form on <M>V</M> and the zeros
 form a <E>conic</E> of the associated projective plane. So in particular,
 our quadratic form defines a degenerate parabolic quadric of Witt Index 1.
 We will see now how we can use <Package>Forms</Package> to view this example.
-<Example>
+<Example><![CDATA[
 gap> gf := GF(8);
 GF(2^3)
 gap> vec := gf^3;
@@ -44,7 +44,7 @@ PolynomialRing(..., [ x_1, x_2, x_3 ])
 gap> poly := r.1^2 + r.2 * r.3;
 x_1^2+x_2*x_3
 gap> form := QuadraticFormByPolynomial( poly, r );
-&lt; quadratic form >
+< quadratic form >
 gap> Display( form );
 Quadratic form
 Gram Matrix:
@@ -62,28 +62,28 @@ gap> WittIndex( form );
 gap> IsParabolicForm( form );
 true
 gap> RadicalOfForm( form );
-&lt;vector space over GF(2^3), with 0 generators>
-</Example>
+<vector space over GF(2^3), with 0 generators>
+]]></Example>
 Now our conic is stabilised by a group isomorphic to
 <Alt Only="Text"><M>GO(3,8)</M></Alt><Alt Only="LaTeX"><M>&go;(3,8)</M></Alt>
 <Alt Only="HTML MathJax"><M>&go;(3,8)</M></Alt><Alt Only="HTML noMathJax">GO(3,8)</Alt>,
 but which is not identical to the group returned by the GAP command
 <C>GO(3,8)</C>. However, our conic is the canonical conic given in <Package>Forms</Package>.
-<Example>
+<Example><![CDATA[
 gap> canonical := IsometricCanonicalForm( form );
-&lt; parabolic quadratic form >
+< parabolic quadratic form >
 gap> form = canonical;
 true
-</Example>
+]]></Example>
 So we ``change forms''...
-<Example>
+<Example><![CDATA[
 gap> go := GO(3,8);
 GO(0,3,8)
 gap> mat := InvariantQuadraticForm( go )!.matrix;
 [ [ Z(2)^0, 0*Z(2), 0*Z(2) ], [ 0*Z(2), 0*Z(2), 0*Z(2) ], 
   [ 0*Z(2), Z(2)^0, 0*Z(2) ] ]
 gap> gapform := QuadraticFormByMatrix( mat, GF(8) );
-&lt; quadratic form >
+< quadratic form >
 gap> b := BaseChangeToCanonical( gapform );
 [ [ Z(2)^0, 0*Z(2), 0*Z(2) ], [ 0*Z(2), Z(2)^0, 0*Z(2) ], 
   [ 0*Z(2), 0*Z(2), Z(2)^0 ] ]
@@ -96,18 +96,18 @@ Group(
            Z(2^3)^6 ] ], 
   [ [ Z(2)^0, 0*Z(2), 0*Z(2) ], [ Z(2)^0, Z(2)^0, Z(2)^0 ], 
       [ 0*Z(2), Z(2)^0, 0*Z(2) ] ] ])
-</Example>
+]]></Example>
 Now we look at the action of our new
 <Alt Only="Text"><M>GO(3,8)</M></Alt><Alt Only="LaTeX"><M>&go;(3,8)</M></Alt>
 <Alt Only="HTML MathJax"><M>&go;(3,8)</M></Alt><Alt Only="HTML noMathJax">GO(3,8)</Alt> on the conic.
-<Example>
+<Example><![CDATA[
 gap> conic := Filtered(vec, x -> IsZero( x^form ));;
 gap> Size(conic);
 64
 gap> orbs := Orbits(newgo, conic, OnRight);;
 gap> List(orbs,Size);
 [ 1, 63 ]
-</Example> 
+]]></Example> 
 So we see that there is a fixed point, which is actually the
 <E>nucleus</E> of the conic, or in other words, the radical
 of the form.

--- a/doc/theory.xml
+++ b/doc/theory.xml
@@ -211,14 +211,14 @@ In the next example, the chosen matrix is somewhat special. Together with the co
 automorphism, it determines a hermitian sesquilinear form. Without the companion
 automorphism, it determines an alternating bilinear form.
 
-<Example>
+<Example><![CDATA[
 gap> mat := [[0*Z(5),0*Z(5),0*Z(25),Z(25)^3],[0*Z(5),0*Z(5),Z(25)^3,0*Z(25)],
 >         [0*Z(5),-Z(25)^3,0*Z(5),0*Z(5)],[-Z(25)^3,0*Z(5),0*Z(25),0*Z(25)]];
 [ [ 0*Z(5), 0*Z(5), 0*Z(5), Z(5^2)^3 ], [ 0*Z(5), 0*Z(5), Z(5^2)^3, 0*Z(5) ], 
   [ 0*Z(5), Z(5^2)^15, 0*Z(5), 0*Z(5) ], 
   [ Z(5^2)^15, 0*Z(5), 0*Z(5), 0*Z(5) ] ]
 gap> form := HermitianFormByMatrix(mat,GF(25));
-&lt; hermitian form >
+< hermitian form >
 gap> Display(form);
 Hermitian form
 Gram Matrix:
@@ -230,7 +230,7 @@ z = Z(25)
 gap> WittIndex(form);
 2
 gap> form2 := BilinearFormByMatrix(mat,GF(25));
-&lt; bilinear form >
+< bilinear form >
 gap> Display(form2);
 Bilinear form
 Gram Matrix:
@@ -257,13 +257,13 @@ Gram Matrix:
  . . . 1
  . . 4 .
 Witt Index: 2
-</Example>
+]]></Example>
 We continue the previous example by exploring a little bit the sesquilinear form
 <A>form</A>, and hence demonstrate some of the functionality of the
 <Package>Forms</Package> package. Eventually, we find a 2-dimensional totally
 isotropic subspace, which lets us conclude that the Witt index of <M>form</M> is at
 least 2, which is confirmed afterwards by calling the appropriate function.
-<Example>
+<Example><![CDATA[
 gap> V := GF(25)^4;
 ( GF(5^2)^4 )
 gap> u := [Z(5)^0,Z(5^2)^11,Z(5)^3,Z(5^2)^13 ];
@@ -295,12 +295,12 @@ gap> [u,w]^form;
 gap> [v,w]^form;
 0*Z(5)
 gap> s := Subspace(V,[v,u,w]);
-&lt;vector space over GF(5^2), with 3 generators>
+<vector space over GF(5^2), with 3 generators>
 gap> Dimension(s);
 2
 gap> WittIndex(form);
 2
-</Example>
+]]></Example>
 </Subsection>
 </Section>
 


### PR DESCRIPTION
This demonstrates the use of CDATA as mentioned in PR #8. Ideally all examples would use it, also those which wrap an `Include` statement, but that's a much bigger change -- one either needs to move the `<Example>` tags into the included file, or else replace the include statements by the actual file content. Both can be done, the question is, what do you want. 