### PR TITLE
doc: generate titlepage using AutoDoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /doc/forms.tex
 /doc/forms.toc
 /doc/manual.*
+/doc/title.xml
 /doc/*.css
 /doc/*.js
 /doc/chooser.html

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -33,7 +33,6 @@ Persons := [
     Email         := "bamberg@maths.uwa.edu.au",
     WWWHome       := "http://school.maths.uwa.edu.au/~bamberg/",
     PostalAddress := Concatenation( [
-                       "John Bamberg\n",
                        "School of Mathematics and Statistics\n",
                        "The University of Western Australia\n",
                        "35 Stirling Highway\n",
@@ -50,7 +49,6 @@ Persons := [
     Email         := "jan@debeule.eu",
     WWWHome       := "http://www.debeule.eu",
     PostalAddress := Concatenation( [
-                       "Jan De Beule\n",
                        "Department of Mathematics\n",
                        "Vrije Universiteit Brussel\n",
                        "Pleinlaan 2\n",
@@ -107,7 +105,19 @@ SourceRepository := rec(
 Keywords := ["Forms", "Sesquilinear", "Quadratic"],
 
 CommunicatedBy := "Leonard Soicher (London)",
-AcceptDate := "03/2009"
+AcceptDate := "03/2009",
+
+
+AutoDoc := rec(
+    TitlePage := rec(
+        Copyright := Concatenation(
+            "&copyright; 2018 by the authors<P/>\n\n",
+            "This package may be distributed under the terms and conditions ",
+            "of the GNU Public License Version 2 or (at your option) any later version.\n"
+            ),
+    )
+),
+
 
 ));
 

--- a/doc/forms.xml
+++ b/doc/forms.xml
@@ -29,48 +29,7 @@
 <?LaTeX ExtraPreamble="\usepackage{url}"?>
 
 <Book Name="Forms">
-
-<TitlePage>
-<Title>GAP 4 Package <Package>Forms</Package></Title>
-<Subtitle>Sesquilinear and Quadratic</Subtitle>
-<Version>
-<#Include SYSTEM "../VERSION">
-</Version>
-
-<Author>John Bamberg
-<Address>
-School of Mathematics and Statistics,
-The University of Western Australia,
-35 Stirling Highway,
-Crawley WA 6009, Perth,
-Western Australia
-</Address>
-<Email>bamberg@maths.uwa.edu.au</Email>
-<Homepage>http://school.maths.uwa.edu.au/~bamberg</Homepage>
-</Author>
-
-<Author>Jan De Beule
-<Address>
-Department of Mathematics,
-Vrije Universiteit Brussel,
-Pleinlaan 2,
-B--1050 Brussel,
-Belgium
-</Address>
-<Email>jan@debeule.eu</Email>
-<Homepage>http://www.debeule.eu</Homepage>
-</Author>
-  
-<Date>September 2018</Date>
-
-<Copyright>
-  &copyright; 2018 by the authors<P/>
-
-  This package may be distributed under the terms and conditions of the
-  GNU Public License Version 2 or higher.
-</Copyright>
-
-</TitlePage>
+<#Include SYSTEM "title.xml">
 
 <!--  TableOfContents  . . . . . .  generate a table of contents   -->
 <TableOfContents/>

--- a/makedoc.g
+++ b/makedoc.g
@@ -7,9 +7,11 @@
 ## tree. Under decent operating systems, you need sufficient permissions to do.
 ## Executing this is NOT necessary for the installation of the package "forms".
 
-if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
-    Error("AutoDoc 2016.01.21 or newer is required");
+if fail = LoadPackage("AutoDoc", ">= 2019.04.10") then
+    Error("AutoDoc 2019.04.10 or newer is required");
 fi;
-AutoDoc("forms");
+AutoDoc(rec(
+    scaffold := rec( MainPage := false ),
+));
 QUIT;
 


### PR DESCRIPTION
This way, it is always in sync with the content of PackageInfo.g, and you don't need the VERSION file anymore (at least not for this purpose).

(The `make_archive.sh` script still uses the `VERSION` file, but it could be replaced with ReleaseTools, see issue #15)