### PR TITLE
README: remove GAPDoc instructions

### DIFF
--- a/README
+++ b/README
@@ -32,17 +32,6 @@ Unpacking generates a subdirectory "forms". Then you can load the package
 by typing in the GAP command line "LoadPackage("forms");". All documentation and
 examples are included.
 
-If typing "LoadPackage("forms");" results in the error message "fail", then
-probably the dependencies are not satisfied. Forms has only two dependencies, it
-requires GAP version at least 4.4 and it requires the package "GAPDoc" version
-at least 0.99. 
-
-You can get the latest version of GAPDoc at the website
-
-http://www.gap-system.org/Packages/gapdoc.html
-
-Installing "GAPDoc" is as easy as installing "Forms".
-
 INSTALLATION *outside the GAP main directory*: When you don't have access to
 the directory of your main GAP installation you can also install the package(s)
 by unpacking inside a directory "MYGAPDIR/pkg", where "MYGAPDIR" is any path in


### PR DESCRIPTION
GAPDoc is a required package in GAP; GAP won't start without it;
so there is no point in discussing how to install it here.
