### PR TITLE
Rewrite `BaseChangeSymplectic`

### DIFF
--- a/tst/basechange.tst
+++ b/tst/basechange.tst
@@ -76,4 +76,28 @@ gap> for dim in [2..10] do
 >    od;
 
 #
+gap> TestBaseChangeSymplectic := function(dim,q)
+>        local F, mat, bc, m;
+>        F := GF(q);
+>        # produce an alternating matrix
+>        mat:=RandomMat(dim,dim,F);
+>        mat:=mat-TransposedMat(mat);
+>        # compute base change
+>        bc:=BaseChangeSymplectic(mat, F);
+>        # verify the base change produces a matrix with the right properties:
+>        m:=bc[1]*mat*TransposedMat(bc[1]);
+>        Assert(0, m = -TransposedMat(m)); # symmetric
+>        # TODO: verify it is canonical
+>    end;;
+
+#
+gap> for dim in [2,10,20,80] do
+>      for q in [2, 3, 4, 5, 7, 8, 9, 25, 27, 17^2] do
+>        for i in [0..3] do
+>          TestBaseChangeSymplectic(dim+i, q);
+>        od;
+>      od;
+>    od;
+
+#
 gap> STOP_TEST("basechange.tst", 0);


### PR DESCRIPTION
Replace multiplication with transformation matrices by direct transformations. On my computer, `TestBaseChangeSymplectic(200,17)` goes from 7730 milliseconds to 140 milliseconds, so 55 times faster.

Also added a bunch of test cases to make sure it (still) works right.

CC @aniemeyer @danielrademacher