### PR TITLE
Make BaseChangeOrthogonalQuadratic faster for large matrices

### DIFF
--- a/tst/test_forms10.tst
+++ b/tst/test_forms10.tst
@@ -8,12 +8,7 @@ x_1*x_6+x_2*x_5+x_3*x_4
 gap> form := QuadraticFormByPolynomial(pol,r,6);
 < quadratic form >
 gap> B := BaseChangeToCanonical(form);
-[ [ Z(2)^0, 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ], 
-  [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2), Z(2)^0 ], 
-  [ 0*Z(2), 0*Z(2), Z(2)^0, 0*Z(2), 0*Z(2), 0*Z(2) ], 
-  [ 0*Z(2), 0*Z(2), 0*Z(2), Z(2)^0, 0*Z(2), 0*Z(2) ], 
-  [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2), Z(2)^0, 0*Z(2) ], 
-  [ 0*Z(2), Z(2)^0, 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ] ]
+< immutable compressed matrix 6x6 over GF(8) >
 gap> mat := form!.matrix;;
 gap> Display(mat);
  . . . . . 1


### PR DESCRIPTION
... by performing row/column transformations directly instead of
via matrix multiplication. This also reduces memory allocation and
thus pressure on the garbage collector.

For comparison here are some timings using `TestBaseChangeOrthogonalQuadratic`
from `tst/basechange.tst` before and after this patch.

Before:

    gap> TestBaseChangeOrthogonalQuadratic(10, 8); [time,memory_allocated];
    [ 1, 318724 ]
    gap> TestBaseChangeOrthogonalQuadratic(100, 8); [time,memory_allocated];
    [ 749, 3507309583 ]
    gap> TestBaseChangeOrthogonalQuadratic(200, 8); [time,memory_allocated];
    [ 7791, 52599049447 ]

After:

    gap> TestBaseChangeOrthogonalQuadratic(10, 8); [time,memory_allocated];
    [ 1, 19984 ]
    gap> TestBaseChangeOrthogonalQuadratic(100, 8); [time,memory_allocated];
    [ 125, 2071775 ]
    gap> TestBaseChangeOrthogonalQuadratic(200, 8); [time,memory_allocated];
    [ 828, 11787839 ]
