### PR TITLE
tst/basechange.tst: ensure base changes yield canonical forms

### DIFF
--- a/lib/forms.gi
+++ b/lib/forms.gi
@@ -2086,7 +2086,7 @@ InstallMethod(BaseChangeOrthogonalQuadratic, [ IsMatrix and IsFFECollColl, IsFie
     for i in [1..n] do
       zeros[i] := zero;
     od;
-    h := Length(Factors(q));
+    h := DegreeOverPrimeField(gf);
     while row + 2 <= r do
       if not IsZero( A[row,row] ) then
         i := row + 1;

--- a/lib/forms.gi
+++ b/lib/forms.gi
@@ -2468,7 +2468,7 @@ InstallMethod( BaseChangeSymplectic, [IsMatrix and IsFFECollColl, IsField and Is
 ## with each block equal to J=[[0,1],[-1,0]].
 
  function(m, f)
-   local d, basechange, blocknr, diagpos, pos, j, a, b;
+   local d, basechange, blocknr, diagpos, pos, j, a, b, offset;
    d := NrRows(m);
    basechange := IdentityMat(d, f);
    ConvertToMatrixRep(basechange, f);
@@ -2478,8 +2478,20 @@ InstallMethod( BaseChangeSymplectic, [IsMatrix and IsFFECollColl, IsField and Is
       ## on the diagonal of m
       diagpos := 2 * blocknr - 1;
 
-      ## find first nonzero entry in column diagpos below the diagonal
-      pos := First([diagpos+1..d], j -> not IsZero( m[diagpos,j] ) );
+      for offset in [0..d-diagpos] do
+         ## find first nonzero entry in column diagpos below the diagonal
+         pos := First([diagpos+1..d], j -> not IsZero( m[diagpos+offset,j] ) );
+         if pos <> fail then
+            if offset <> 0 then
+               Forms_SwapRows(basechange, diagpos, diagpos+offset);
+               Forms_SwapRows(m, diagpos, diagpos+offset);
+               Forms_SwapCols(m, diagpos, diagpos+offset);
+               pos := First([diagpos+1..d], j -> not IsZero( m[diagpos,j] ) );
+               Assert(0, pos <> fail);
+            fi;
+            break;
+         fi;
+      od;
 
       # when pos=fail, then only degeneracy is left and the base transition is complete
       if pos=fail then

--- a/tst/basechange.tst
+++ b/tst/basechange.tst
@@ -1,103 +1,178 @@
-gap> START_TEST("basechange.tst");
+# don't invoke START_TEST, which resets the random number generators,
+# so that we can re-read this .tst file multiple times to test more cases.
+#gap> START_TEST("basechange.tst");
 
 #
+gap> MakeCanonicalOrthogonalBilinear := function(dim,F,rank,w)
+>        local A, e, i, offset;
+>        A:=NullMat(dim,dim,F);
+>        e:=One(F);
+>        if w = 0 then
+>          A[1,1] := e;
+>          if Size(F) mod 4 = 3 then
+>            A[2,2] := e;
+>          else
+>            A[2,2] := PrimitiveRoot(F);
+>          fi;
+>        elif w = 1 then
+>          A[1,1] := e;
+>        else
+>          Assert(0, w = 2);
+>        fi;
+>        offset := 2-w;
+>        for i in [1..QuoInt(rank - offset,2)] do
+>          A[offset+2*i,offset+2*i-1] := e/2;
+>          A[offset+2*i-1,offset+2*i] := e/2;
+>        od;
+>        return A;
+>    end;;
 gap> TestBaseChangeOrthogonalBilinear := function(dim,q)
->        local F, mat, bc, m;
+>        local F, mat, bc, m, c;
 >        F := GF(q);
 >        # produce a symmetric matrix
->        mat:=RandomInvertibleMat(dim,F);
+>        mat:=RandomMat(dim,dim,F);
 >        mat:=mat+TransposedMat(mat);
+>        if IsZero(mat) then return; fi;
 >        # compute base change
 >        bc:=BaseChangeOrthogonalBilinear(mat, F);
->        # verify the base change produces a matrix with the right properties:
+>        Assert(0, dim = RankMat(bc[1]));
+>        Assert(0, bc[2]+1 = RankMat(mat));  # FIXME: why +1?
+>        # verify the base change really yields the canonical form
 >        m:=bc[1]*mat*TransposedMat(bc[1]);
->        Assert(0, m = TransposedMat(m)); # symmetric
->        # TODO: verify it is canonical
+>        c := MakeCanonicalOrthogonalBilinear(dim,F,bc[2]+1,bc[3]);
+>        # HACK: 'normalize' both matrices
+>        Assert(0, m/First(m[1],x->not IsZero(x)) = c/First(c[1],x->not IsZero(x)));
 >    end;;
 
 #
-gap> for dim in [2,10,20,80] do
+gap> for dim in [2,10,20] do
 >      for q in [3, 5, 7, 9, 25, 27, 17^2] do
->        for i in [0..3] do
+>        for i in [0..4] do
 >          TestBaseChangeOrthogonalBilinear(dim+i, q);
 >        od;
 >      od;
 >    od;
 
 #
+gap> MakeCanonicalOrthogonalQuadratic := function(dim,F,rank,w)
+>        local A, e, i, offset;
+>        A:=NullMat(dim,dim,F);
+>        e:=One(F);
+>        if w = 0 then
+>          A[1,1] := e;
+>          A[1,2] := e;
+>          A[2,2] := Forms_C1(F, DegreeOverPrimeField(F));
+>        elif w = 1 then
+>          A[1,1] := e;
+>        else
+>          Assert(0, w = 2);
+>        fi;
+>        offset := 2-w;
+>        for i in [1..QuoInt(rank - offset,2)] do
+>          A[offset+2*i-1,offset+2*i] := e;
+>        od;
+>        return A;
+>    end;;
 gap> TestBaseChangeOrthogonalQuadratic := function(dim,q)
->        local F, mat, i, j, bc, m;
+>        local F, mat, i, j, bc, m, c;
 >        F := GF(q);
->        # produce a symmetric matrix
->        mat:=RandomMat(dim,dim,F);
->        for i in [2..dim] do
->          for j in [1..i-1] do
->            mat[i,j] := Zero(F);
+>        # produce upper triangular matrix
+>        mat:=NullMat(dim,dim,F);
+>        for i in [1..dim] do
+>          for j in [i..dim] do
+>            mat[i,j] := Random(F);
 >          od;
 >        od;
->        #mat:=mat+TransposedMat(mat);
+>        if IsZero(mat) then return; fi;
 >        # compute base change
 >        bc:=BaseChangeOrthogonalQuadratic(mat, F);
->        # verify the base change produces a matrix with the right properties:
+>        Assert(0, dim = RankMat(bc[1]));
+>        #Assert(0, bc[2] = RankMat(mat));  # FIXME: what does bc[2] really mean?
+>        # verify the base change really yields the canonical form
 >        m:=bc[1]*mat*TransposedMat(bc[1]);
->        #Assert(0, m=TransposedMat(m)); # symmetric
->        # TODO: verify it is canonical
+>        c:=MakeCanonicalOrthogonalQuadratic(dim,F,bc[2]+1,bc[3]);
+>        Assert(0, Forms_RESET(m, dim, q) = c);
 >    end;;
-gap> for dim in [3..10] do
+
+#
+gap> for dim in [2,10,20] do
 >      for q in [2, 4, 8, 16, 2^9] do
->        for i in [1..5] do
->          TestBaseChangeOrthogonalQuadratic(dim, q);
+>        for i in [0..4] do
+>          TestBaseChangeOrthogonalQuadratic(dim+1, q);
 >        od;
 >      od;
 >    od;
 
 #
+gap> MakeCanonicalHermitian := function(dim,F,rank)
+>        local A, e, i;
+>        A:=NullMat(dim,dim,F);
+>        e:=One(F);
+>        for i in [1..rank] do
+>          A[i,i] := e;
+>        od;
+>        return A;
+>    end;;
 gap> TestBaseChangeHermitian := function(dim,q)
->        local F, mat, bc, m;
+>        local F, mat, bc, m, c;
 >        F := GF(q^2);
 >        # produce a symmetric matrix
 >        mat:=RandomInvertibleMat(dim,F);
 >        mat:=mat+Forms_HERM_CONJ(mat, q);
+>        if IsZero(mat) then return; fi;
 >        # compute base change
 >        bc:=BaseChangeHermitian(mat, F);
->        # verify the base change produces a matrix with the right properties:
+>        Assert(0, dim = RankMat(bc[1]));
+>        # verify the base change really yields the canonical form
 >        m:=bc[1]*mat*Forms_HERM_CONJ(bc[1], q);
->        Assert(0, m = Forms_HERM_CONJ(m, q));
->        # TODO: verify it is canonical
+>        c:=MakeCanonicalHermitian(dim,F,RankMat(mat));
+>        Assert(0, m = c);
 >    end;;
 
 #
-gap> for dim in [2..10] do
+gap> for dim in [2,10,20] do
 >      for q in [2, 3, 4, 5, 7, 9, 16, 25, 27, 17^2] do
->        for i in [1..5] do
->          TestBaseChangeHermitian(dim, q);
+>        for i in [0..4] do
+>          TestBaseChangeHermitian(dim+i, q);
 >        od;
 >      od;
 >    od;
 
 #
+gap> MakeCanonicalSymplectic := function(dim,F,rank)
+>        local A, e, i;
+>        A:=NullMat(dim,dim,F);
+>        e:=One(F);
+>        for i in [1..QuoInt(rank,2)] do
+>          A[2*i,2*i-1] := -e;
+>          A[2*i-1,2*i] := e;
+>        od;
+>        return A;
+>    end;;
 gap> TestBaseChangeSymplectic := function(dim,q)
->        local F, mat, bc, m;
+>        local F, mat, bc, m, c;
 >        F := GF(q);
 >        # produce an alternating matrix
 >        mat:=RandomMat(dim,dim,F);
 >        mat:=mat-TransposedMat(mat);
+>        if IsZero(mat) then return; fi;
 >        # compute base change
 >        bc:=BaseChangeSymplectic(mat, F);
->        # verify the base change produces a matrix with the right properties:
+>        Assert(0, dim = RankMat(bc[1]));
+>        # verify the base change really yields the canonical form
 >        m:=bc[1]*mat*TransposedMat(bc[1]);
->        Assert(0, m = -TransposedMat(m)); # symmetric
->        # TODO: verify it is canonical
+>        c:=MakeCanonicalSymplectic(dim,F,RankMat(mat));
+>        Assert(0, m = c);
 >    end;;
 
 #
-gap> for dim in [2,10,20,80] do
+gap> for dim in [2,10,20] do
 >      for q in [2, 3, 4, 5, 7, 8, 9, 25, 27, 17^2] do
->        for i in [0..3] do
->          TestBaseChangeSymplectic(dim+i, q);
+>        for i in [0..4] do
+>          TestBaseChangeSymplectic(dim, q);
 >        od;
 >      od;
 >    od;
 
 #
-gap> STOP_TEST("basechange.tst", 0);
+#gap> STOP_TEST("basechange.tst", 0);


### PR DESCRIPTION
The new tests (still) don't pass, due to bugs in the code -- but those are not recent, they've been present since at least forms version 1.2.2 shipped in GAP 4.5.7.

See issues #58 and #65.


UPDATE: the bug in the symplectic case wasn't hard to find and fix, so this PR now fixes #58

UPDATE 2: issue #65 turned out to be an issue in the documentation, not the code; I've adjusted the test and they now pass!