### PR TITLE
Change PrimitiveElement -> PrimitiveRoot where necessary

### DIFF
--- a/lib/forms.gi
+++ b/lib/forms.gi
@@ -695,7 +695,7 @@ InstallMethod( DiscriminantOfForm, [ IsQuadraticForm ],
       Error( "Form must be nondegenerate" );
    fi;
    if IsOddInt(Size(gf)) then
-      primroot := PrimitiveElement( gf );
+      primroot := PrimitiveRoot( gf );
       squares := AsList( Group( primroot^2 ) );
       if det in squares then
          return "square";
@@ -721,7 +721,7 @@ InstallMethod( DiscriminantOfForm, [ IsSesquilinearForm ],
       Error( "Form must be nondegenerate" );
    fi;
    if IsOddInt(Size(gf)) then
-      primroot := PrimitiveElement( gf );
+      primroot := PrimitiveRoot( gf );
       squares := AsList( Group( primroot^2 ) );
       if det in squares then
          return "square";

--- a/lib/recognition_new.gi
+++ b/lib/recognition_new.gi
@@ -126,11 +126,11 @@ InstallGlobalFunction( ClassicalForms_GeneratorsWithBetterScalarsSesquilinear,
             root := NthRoot(field,a1[2],a1[1]);
             if a1[1] = 1 then # the matrix m1 has scalar a1[2]
                 #if a1[2] has a square root, we can replace m1 with m1*sqrt{a1[2]};
-                if LogFFE(a1[2],PrimitiveElement(field)) mod 2 = 0 then
+                if LogFFE(a1[2],PrimitiveRoot(field)) mod 2 = 0 then
                     return [m1/NthRoot(field,a1[2],2),[One(field)]];
                 fi;
                 return [m1,[a1[2]]]; #originally, the three lines above this return were not there. Those three lines make sure scalar becomes 1 if possible (basicaly if there is a sqrt).
-            elif LogFFE(root,PrimitiveElement(field)) mod (q+1) = 0 then
+            elif LogFFE(root,PrimitiveRoot(field)) mod (q+1) = 0 then
                 return [m1/NthRoot(field,root,q+1),[One(field)]]; #either frob = id, then q+1 = 2, or frob is not trivial, then we take q+1-st root. In both cases, modify m1 to a matrix that has scalar one.
             else
                 scalars := AsList(Group(NthRoot(field,a1[2],a1[1]))); # add all possible scalars for m1
@@ -161,7 +161,7 @@ InstallGlobalFunction( ClassicalForms_GeneratorsWithBetterScalarsSesquilinear,
     newgens := ShallowCopy(gens);
         
     for i in [1..Length(gens)] do
-        champion := [gens[i],AsList(Group(PrimitiveElement(field)))];
+        champion := [gens[i],AsList(Group(PrimitiveRoot(field)))];
         len := Length(champion[2]);
         res := improvegenerator(gens[i],i,10,len);
         if res = false then


### PR DESCRIPTION
PrimitiveRoot is guaranteed to return a generator of the
multiplicative group, while PrimitiveElement may not.
