### PR TITLE
Adjust `ConformalSymplecticGroup` to matrix object changes

### DIFF
--- a/lib/conformal.gi
+++ b/lib/conformal.gi
@@ -115,23 +115,30 @@ InstallMethod( ConformalSymplecticGroupCons,
     "IsField and IsFinite",
     "IsBilinearForm" ],
   function( filt, d, F, form )
-  local g, stored, wanted, mat1, mat2, mat, matinv, gens, gg;
+  local g, stored, matrix_filt, form_matrix, wanted, mat1, mat2, mat, matinv,
+        gens, gg;
 
   # Create the default generators and form.
   g:= ConformalSymplecticGroupCons( filt, d, F );
   stored:= InvariantBilinearFormUpToScalars( g ).matrix;
+  matrix_filt:= ConstructingFilter( stored );
+  Assert( 1, ForAll( GeneratorsOfGroup( g ),
+                     x -> ConstructingFilter( x ) = matrix_filt ) );
 
   # If the prescribed form fits then just return.
-  if stored = form!.matrix then
+  # We do not require that 'form!.matrix' is in 'matrix_filt',
+  # only its entries describe the desired form.
+  form_matrix:= Matrix( matrix_filt, F, form!.matrix );
+  if stored = form_matrix then
     return g;
   fi;
 
   # Compute a base change matrix.
   # (Check that the canonical forms are equal.)
   wanted:= BilinearFormByMatrix( stored, F );
-  mat1:= BaseChangeToCanonical( form );
-  mat2:= BaseChangeToCanonical( wanted );
-  if mat1 * form!.matrix * TransposedMat( mat1 ) <>
+  mat1:= Matrix( matrix_filt, F, BaseChangeToCanonical( form ) );
+  mat2:= Matrix( matrix_filt, F, BaseChangeToCanonical( wanted ) );
+  if mat1 * form_matrix * TransposedMat( mat1 ) <>
      mat2 * stored * TransposedMat( mat2 ) then
     Error( "canonical forms of <form> and <wanted> differ" );
   fi;
@@ -139,8 +146,7 @@ InstallMethod( ConformalSymplecticGroupCons,
   matinv:= mat^-1;
 
   # Create the group w.r.t. the prescribed form.
-  gens:= List( GeneratorsOfGroup( g ),
-               x -> Matrix( matinv * x * mat, stored ) );
+  gens:= List( GeneratorsOfGroup( g ), x -> matinv * x * mat );
   gg:= GroupWithGenerators( gens );
 
   UseIsomorphismRelation( g, gg );
@@ -150,7 +156,7 @@ InstallMethod( ConformalSymplecticGroupCons,
   fi;
 
   SetInvariantBilinearFormUpToScalars( gg,
-    rec( matrix:= Matrix( form!.matrix, stored ), baseDomain:= F ) );
+    rec( matrix:= form_matrix, baseDomain:= F ) );
 
   if HasIsFullSubgroupGLRespectingBilinearFormUpToScalars( g ) then
     SetIsFullSubgroupGLRespectingBilinearFormUpToScalars( gg,

--- a/tst/adv/conformal.tst
+++ b/tst/adv/conformal.tst
@@ -1,18 +1,18 @@
-#@local is_equal, q, F, d, filt, g, stored, pi, permmat, form, gg, pg, sp
+#@local q, F, d, filts, filt, g, stored, pi, permmat, form, gg, pg, sp
 
 gap> START_TEST( "Forms: conformal.tst" );
-
-# Provide an auxiliary function (until GAP's '=' gets fast).
-gap> is_equal:= function( G1, G2 )
->      return IsSubset( G1, GeneratorsOfGroup( G2 ) ) and
->             IsSubset( G2, GeneratorsOfGroup( G1 ) );
->    end;;
 
 # Test the creation of conformal symplectic groups.
 gap> for q in [ 2, 3, 4, 5, 7, 8, 9, 11, 13, 16, 17, 19, 23, 25 ] do
 >      F:= GF(q);
 >      for d in [ 2, 4 .. 8 ] do
->        for filt in [ IsPlistRep, IsPlistMatrixRep ] do
+>        filts:= [ IsPlistRep, IsPlistMatrixRep ];
+>        if q = 2 then
+>          Add( filts, IsGF2MatrixRep );
+>        elif q <= 256 then
+>          Add( filts, Is8BitMatrixRep );
+>        fi;
+>        for filt in filts do
 >          PushOptions( rec( ConstructingFilter:= filt ) );
 > 
 >          g:= ConformalSymplecticGroup( d, F );
@@ -30,24 +30,23 @@ gap> for q in [ 2, 3, 4, 5, 7, 8, 9, 11, 13, 16, 17, 19, 23, 25 ] do
 >          if filt <> IsPlistRep and not filt( One( gg ) ) then
 >            Error( "wrong repres. of matrices" );
 >          fi;
->          if not ( is_equal( g, ConformalSymplecticGroup( g ) ) and
->                   ( is_equal( g, ConformalSymplecticGroup( stored ) ) or
+>          if not ( g = ConformalSymplecticGroup( g ) and
+>                   ( g = ConformalSymplecticGroup( stored ) or
 >                     BaseDomain( stored ) <> F ) and
->                   is_equal( g, ConformalSymplecticGroup( d, q ) ) and
->                   is_equal( g, ConformalSymplecticGroup( form ) ) and
->                   is_equal( g, ConformalSymplecticGroup( d, q, g ) ) and
->                   is_equal( g, ConformalSymplecticGroup( d, q, stored ) ) and
->                   is_equal( g, ConformalSymplecticGroup( d, q, form ) ) and
->                   is_equal( g, ConformalSymplecticGroup( d, F, g ) ) and
->                   is_equal( g, ConformalSymplecticGroup( d, F, stored ) ) and
->                   is_equal( g, ConformalSymplecticGroup( d, F, form ) ) and
+>                   g = ConformalSymplecticGroup( d, q ) and
+>                   g = ConformalSymplecticGroup( form ) and
+>                   g = ConformalSymplecticGroup( d, q, g ) and
+>                   g = ConformalSymplecticGroup( d, q, stored ) and
+>                   g = ConformalSymplecticGroup( d, q, form ) and
+>                   g = ConformalSymplecticGroup( d, F, g ) and
+>                   g = ConformalSymplecticGroup( d, F, stored ) and
+>                   g = ConformalSymplecticGroup( d, F, form ) and
 >                   IsSubset( gg, GeneratorsOfGroup( gg ) ) and
 >                   IsSubset( g, List( GeneratorsOfGroup( gg ), x -> x^pi ) ) ) then
 >            Error( "problem with CSp(", d, ",", q, ")" );
 >          fi;
 > 
->          if Size( g ) < 10^7 and filt = IsPlistRep then
-> # Change this as soon as also `IsPlistMatrixRep` works!
+>          if Size( g ) < 10^7 then
 >            pg:= ConformalSymplecticGroup( IsPermGroup, d, q );
 >            if Size( g ) <> Size( pg ) then
 >              Error( "problem with CSp(IsPermGroup, ", d, ",", q, ")" );
@@ -59,8 +58,7 @@ gap> for q in [ 2, 3, 4, 5, 7, 8, 9, 11, 13, 16, 17, 19, 23, 25 ] do
 >            Error( "wrong repres. of matrices" );
 >          fi;
 >          g:= ConformalSymplecticGroup( sp );
->        # if not IsSubset( g, sp ) then   # make this fast in the GAP library
->          if ForAny( GeneratorsOfGroup( sp ), x -> not x in g ) then
+>          if not IsSubset( g, sp ) then
 >            Error( "problem with CSp(", d, ",", q, ")" );
 >          fi;
 > 


### PR DESCRIPTION
Now we make sure that all matrix multiplications happen w. r. t. the same representation.

Note that issue #6221 of GAP describes possible problems, and pull request #6240 of GAP provides a fix, which causes in our situation that some multiplications are no longer allowed.

Thus we turn all matrices stored in forms objects into matrices that fit to the representation of the given group generators.
Also, we use `Matrix` only in the variant that prescribes `ConstructingFilter` and `BaseDomain`, the variant that prescribes
just an example matrix object is dangerous in the situation that we are dealing with `IsGF2MAtrixRep` or `Is8BitMatrixRep`
matrices.

(Eventually it will be desirable to admit matrix objects of the right representation also in as data of the forms objects, but this is nothing we can force now.)

And revisit the ConformalSymplecticGroup tests:

- test more filters (we have learned that `IsGF2MatrixRep` and   `Is8BitMatrixRep` need explicit checks)
- add some tests that were commented out but now work due to improvements in the GAP library
- test equality of groups with `\=` not with an artificial `is_equal` function, which is possible (and in fact faster) due to improvements in the GAP library